### PR TITLE
Repositories as services

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ final class Project extends BaseEntity
 {
 }
 ```
+
 Then a repository:
 
 ```php
@@ -198,11 +199,14 @@ use App\Wordpress\Entity\Project;use Symfony\Component\Serializer\SerializerInte
  */
 final class ProjectRepository extends AbstractEntityRepository
 {
-    protected const POST_TYPE = 'project';
-
-    public function __construct(protected EntityManagerInterface $entityManager, SerializerInterface $serializer)
+    public function __construct(/* inject additional services if you need them */)
     {
-        parent::__construct($entityManager, $serializer, Project::class);
+        parent::__construct(Project::class);
+    }
+    
+    protected function getPostType(): string
+    {
+        return 'project';
     }
     
     // Add your own methods here

--- a/src/AbstractEntityManager.php
+++ b/src/AbstractEntityManager.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop;
+
+use Doctrine\DBAL\Connection;
+use ReflectionClass;
+use Symfony\Component\Serializer\SerializerInterface;
+use Williarin\WordpressInterop\Attributes\RepositoryClass;
+use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
+
+abstract class AbstractEntityManager implements EntityManagerInterface
+{
+    private array $repositories = [];
+
+    public function __construct(
+        private Connection $connection,
+        protected SerializerInterface $serializer,
+        private string $tablePrefix = 'wp_'
+    ) {
+    }
+
+    public function addRepository(RepositoryInterface $repository): EntityManagerInterface
+    {
+        $this->repositories[$repository->getEntityClassName()] = $repository;
+
+        return $this;
+    }
+
+    /**
+     * @return RepositoryInterface[]
+     */
+    public function getRepositories(): array
+    {
+        return $this->repositories;
+    }
+
+    public function getRepository(string $entityClassName): RepositoryInterface
+    {
+        if (empty($this->repositories[$entityClassName])) {
+            $this->repositories[$entityClassName] = $this->getRepositoryServiceForClass($entityClassName);
+        }
+
+        $this->repositories[$entityClassName]->setEntityManager($this);
+
+        return $this->repositories[$entityClassName];
+    }
+
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    public function getTablesPrefix(): string
+    {
+        return $this->tablePrefix;
+    }
+
+    abstract protected function getRepositoryServiceForClass(?string $entityClassName): RepositoryInterface;
+
+    protected function getRepositoryNameForClass(string $entityClassName): ?string
+    {
+        if (class_exists($entityClassName)) {
+            $reflectionClass = new ReflectionClass($entityClassName);
+
+            if ($attribute = current($reflectionClass->getAttributes(RepositoryClass::class))) {
+                return $attribute->newInstance()
+                    ->className;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -86,18 +86,18 @@ use function Williarin\WordpressInterop\Util\String\property_to_field;
  * @method bool         updatePostMimeType(int $id, string $newValue)
  * @method bool         updateCommentCount(int $id, int $newValue)
  */
-abstract class AbstractEntityRepository implements RepositoryInterface
+abstract class AbstractEntityRepository implements EntityRepositoryInterface
 {
     protected const MAPPED_FIELDS = [];
+    protected EntityManagerInterface $entityManager;
+    protected SerializerInterface $serializer;
 
     private array $entityBaseFields = [];
     private array $entityExtraFields = [];
     private PropertyNormalizer $propertyNormalizer;
 
     public function __construct(
-        protected EntityManagerInterface $entityManager,
-        protected SerializerInterface $serializer,
-        private string $entityClassName
+        private string $entityClassName,
     ) {
         $this->propertyNormalizer = new PropertyNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
     }
@@ -192,6 +192,16 @@ abstract class AbstractEntityRepository implements RepositoryInterface
         ;
 
         return $affectedRows > 0;
+    }
+
+    public function setEntityManager(EntityManagerInterface $entityManager): void
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function setSerializer(SerializerInterface $serializer): void
+    {
+        $this->serializer = $serializer;
     }
 
     /**

--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -88,7 +88,6 @@ use function Williarin\WordpressInterop\Util\String\property_to_field;
  */
 abstract class AbstractEntityRepository implements RepositoryInterface
 {
-    protected const POST_TYPE = 'post';
     protected const MAPPED_FIELDS = [];
 
     private array $entityBaseFields = [];
@@ -154,7 +153,7 @@ abstract class AbstractEntityRepository implements RepositoryInterface
             ->from($this->entityManager->getTablesPrefix() . 'posts')
             ->where('post_type = :post_type')
             ->setParameters([
-                'post_type' => static::POST_TYPE,
+                'post_type' => $this->getPostType(),
             ])
             ->executeQuery()
             ->fetchAllAssociative()
@@ -247,6 +246,11 @@ abstract class AbstractEntityRepository implements RepositoryInterface
         $value = $this->validateFieldValue($field, $value);
 
         return (string) $this->serializer->normalize($value);
+    }
+
+    protected function getPostType(): string
+    {
+        return 'post';
     }
 
     private function doFindOneBy(string $name, array $arguments): BaseEntity
@@ -397,7 +401,7 @@ abstract class AbstractEntityRepository implements RepositoryInterface
             ->select($this->getPrefixedEntityBaseFields('p'))
             ->from($this->entityManager->getTablesPrefix() . 'posts', 'p')
             ->where('post_type = :post_type')
-            ->setParameter('post_type', static::POST_TYPE)
+            ->setParameter('post_type', $this->getPostType())
         ;
 
         $extraFields = $this->getEntityExtraFields();

--- a/src/Bridge/Repository/AttachmentRepository.php
+++ b/src/Bridge/Repository/AttachmentRepository.php
@@ -59,8 +59,6 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class AttachmentRepository extends AbstractEntityRepository
 {
-    protected const POST_TYPE = 'attachment';
-
     protected const MAPPED_FIELDS = [
         '_wp_attached_file' => 'attached_file',
         '_wp_attachment_metadata' => 'attachment_metadata',
@@ -104,5 +102,10 @@ final class AttachmentRepository extends AbstractEntityRepository
         ;
 
         return $this->denormalize($result, Attachment::class);
+    }
+
+    protected function getPostType(): string
+    {
+        return 'attachment';
     }
 }

--- a/src/Bridge/Repository/AttachmentRepository.php
+++ b/src/Bridge/Repository/AttachmentRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Attachment;
-use Williarin\WordpressInterop\EntityManagerInterface;
 
 /**
  * @method Attachment   find($id)
@@ -64,11 +62,9 @@ final class AttachmentRepository extends AbstractEntityRepository
         '_wp_attachment_metadata' => 'attachment_metadata',
     ];
 
-    public function __construct(
-        protected EntityManagerInterface $entityManager,
-        protected SerializerInterface $serializer
-    ) {
-        parent::__construct($entityManager, $serializer, Attachment::class);
+    public function __construct()
+    {
+        parent::__construct(Attachment::class);
     }
 
     public function getFeaturedImage(int $postId): Attachment

--- a/src/Bridge/Repository/EntityRepositoryInterface.php
+++ b/src/Bridge/Repository/EntityRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Bridge\Repository;
+
+use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
+
+interface EntityRepositoryInterface extends RepositoryInterface
+{
+    public function find(int $id): BaseEntity;
+
+    public function findOneBy(array $criteria, array $orderBy = null): BaseEntity;
+
+    public function findAll(): array;
+
+    public function findBy(array $criteria, array $orderBy = null, ?int $limit = null, int $offset = null): array;
+
+    public function updateSingleField(int $id, string $field, mixed $newValue): bool;
+}

--- a/src/Bridge/Repository/OptionRepository.php
+++ b/src/Bridge/Repository/OptionRepository.php
@@ -25,12 +25,8 @@ final class OptionRepository implements RepositoryInterface
     public const OPTION_SITE_URL = 'siteurl';
     public const OPTION_BLOG_NAME = 'blogname';
     public const OPTION_BLOG_DESCRIPTION = 'blogdescription';
-
-    public function __construct(
-        private EntityManagerInterface $entityManager,
-        SerializerInterface $serializer
-    ) {
-    }
+    private EntityManagerInterface $entityManager;
+    private SerializerInterface $serializer;
 
     public function __call(string $name, array $arguments): string|array|null
     {
@@ -148,5 +144,15 @@ final class OptionRepository implements RepositoryInterface
         ;
 
         return $affectedRows > 0;
+    }
+
+    public function setEntityManager(EntityManagerInterface $entityManager): void
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function setSerializer(SerializerInterface $serializer): void
+    {
+        $this->serializer = $serializer;
     }
 }

--- a/src/Bridge/Repository/PageRepository.php
+++ b/src/Bridge/Repository/PageRepository.php
@@ -57,12 +57,15 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class PageRepository extends AbstractEntityRepository
 {
-    protected const POST_TYPE = 'page';
-
     public function __construct(
         protected EntityManagerInterface $entityManager,
         SerializerInterface $serializer
     ) {
         parent::__construct($entityManager, $serializer, Page::class);
+    }
+
+    protected function getPostType(): string
+    {
+        return 'page';
     }
 }

--- a/src/Bridge/Repository/PageRepository.php
+++ b/src/Bridge/Repository/PageRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Page;
-use Williarin\WordpressInterop\EntityManagerInterface;
 
 /**
  * @method Page   find($id)
@@ -57,11 +55,9 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class PageRepository extends AbstractEntityRepository
 {
-    public function __construct(
-        protected EntityManagerInterface $entityManager,
-        SerializerInterface $serializer
-    ) {
-        parent::__construct($entityManager, $serializer, Page::class);
+    public function __construct()
+    {
+        parent::__construct(Page::class);
     }
 
     protected function getPostType(): string

--- a/src/Bridge/Repository/PostMetaRepository.php
+++ b/src/Bridge/Repository/PostMetaRepository.php
@@ -13,11 +13,8 @@ use function Williarin\WordpressInterop\Util\String\unserialize_if_needed;
 
 final class PostMetaRepository implements RepositoryInterface
 {
-    public function __construct(
-        private EntityManagerInterface $entityManager,
-        SerializerInterface $serializer
-    ) {
-    }
+    private EntityManagerInterface $entityManager;
+    private SerializerInterface $serializer;
 
     public function getEntityClassName(): string
     {
@@ -119,5 +116,15 @@ final class PostMetaRepository implements RepositoryInterface
         ;
 
         return $affectedRows > 0;
+    }
+
+    public function setEntityManager(EntityManagerInterface $entityManager): void
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function setSerializer(SerializerInterface $serializer): void
+    {
+        $this->serializer = $serializer;
     }
 }

--- a/src/Bridge/Repository/PostRepository.php
+++ b/src/Bridge/Repository/PostRepository.php
@@ -57,8 +57,6 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class PostRepository extends AbstractEntityRepository
 {
-    protected const POST_TYPE = 'post';
-
     public function __construct(
         protected EntityManagerInterface $entityManager,
         SerializerInterface $serializer

--- a/src/Bridge/Repository/PostRepository.php
+++ b/src/Bridge/Repository/PostRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Post;
-use Williarin\WordpressInterop\EntityManagerInterface;
 
 /**
  * @method Post   find($id)
@@ -57,10 +55,8 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class PostRepository extends AbstractEntityRepository
 {
-    public function __construct(
-        protected EntityManagerInterface $entityManager,
-        SerializerInterface $serializer
-    ) {
-        parent::__construct($entityManager, $serializer, Post::class);
+    public function __construct()
+    {
+        parent::__construct(Post::class);
     }
 }

--- a/src/Bridge/Repository/ProductRepository.php
+++ b/src/Bridge/Repository/ProductRepository.php
@@ -110,8 +110,6 @@ use Williarin\WordpressInterop\EntityManagerInterface;
  */
 final class ProductRepository extends AbstractEntityRepository
 {
-    protected const POST_TYPE = 'product';
-
     protected const MAPPED_FIELDS = [
         'sku',
         'sale_price_dates_from',
@@ -154,5 +152,10 @@ final class ProductRepository extends AbstractEntityRepository
         SerializerInterface $serializer
     ) {
         parent::__construct($entityManager, $serializer, Product::class);
+    }
+
+    protected function getPostType(): string
+    {
+        return 'product';
     }
 }

--- a/src/Bridge/Repository/ProductRepository.php
+++ b/src/Bridge/Repository/ProductRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Product;
-use Williarin\WordpressInterop\EntityManagerInterface;
 
 /**
  * @method Product   find($id)
@@ -147,11 +145,9 @@ final class ProductRepository extends AbstractEntityRepository
         'sale_price',
     ];
 
-    public function __construct(
-        protected EntityManagerInterface $entityManager,
-        SerializerInterface $serializer
-    ) {
-        parent::__construct($entityManager, $serializer, Product::class);
+    public function __construct()
+    {
+        parent::__construct(Product::class);
     }
 
     protected function getPostType(): string

--- a/src/Bridge/Repository/RepositoryInterface.php
+++ b/src/Bridge/Repository/RepositoryInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
+use Symfony\Component\Serializer\SerializerInterface;
+use Williarin\WordpressInterop\EntityManagerInterface;
+
 interface RepositoryInterface
 {
     public function getEntityClassName(): string;
+
+    public function setEntityManager(EntityManagerInterface $entityManager): void;
+
+    public function setSerializer(SerializerInterface $serializer): void;
 }

--- a/test/Fixture/Repository/FooRepository.php
+++ b/test/Fixture/Repository/FooRepository.php
@@ -11,9 +11,9 @@ use Williarin\WordpressInterop\Test\Fixture\Entity\Foo;
 
 final class FooRepository extends AbstractEntityRepository
 {
-    public function __construct(protected EntityManagerInterface $entityManager, SerializerInterface $serializer)
+    public function __construct()
     {
-        parent::__construct($entityManager, $serializer, Foo::class);
+        parent::__construct(Foo::class);
     }
 
     public function getFooTerms(): array

--- a/test/Test/Bridge/Repository/AbstractEntityRepositoryTest.php
+++ b/test/Test/Bridge/Repository/AbstractEntityRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
 use Williarin\WordpressInterop\Bridge\Entity\Post;
-use Williarin\WordpressInterop\Bridge\Repository\AbstractEntityRepository;
+use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Exception\InvalidArgumentException;
 use Williarin\WordpressInterop\Exception\InvalidFieldNameException;
 use Williarin\WordpressInterop\Exception\InvalidTypeException;
@@ -13,12 +13,12 @@ use Williarin\WordpressInterop\Test\TestCase;
 
 class AbstractEntityRepositoryTest extends TestCase
 {
-    private AbstractEntityRepository $repository;
+    private EntityRepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new class ($this->manager, $this->serializer, Post::class) extends AbstractEntityRepository {};
+        $this->repository = $this->manager->getRepository(Post::class);
     }
 
     public function testUpdateSingleField(): void

--- a/test/Test/Bridge/Repository/AttachmentRepositoryTest.php
+++ b/test/Test/Bridge/Repository/AttachmentRepositoryTest.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
-use Williarin\WordpressInterop\Bridge\Repository\AttachmentRepository;
+use Williarin\WordpressInterop\Bridge\Entity\Attachment;
+use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Test\TestCase;
 
 class AttachmentRepositoryTest extends TestCase
 {
-    private AttachmentRepository $repository;
+    private EntityRepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new AttachmentRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(Attachment::class);
     }
 
     public function testFindAttachmentPopulatesAttributes(): void

--- a/test/Test/Bridge/Repository/OptionRepositoryTest.php
+++ b/test/Test/Bridge/Repository/OptionRepositoryTest.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
-use Williarin\WordpressInterop\Bridge\Repository\OptionRepository;
+use Williarin\WordpressInterop\Bridge\Entity\Option;
+use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
 use Williarin\WordpressInterop\Exception\OptionAlreadyExistsException;
 use Williarin\WordpressInterop\Exception\OptionNotFoundException;
 use Williarin\WordpressInterop\Test\TestCase;
 
 class OptionRepositoryTest extends TestCase
 {
-    private OptionRepository $repository;
+    private RepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new OptionRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(Option::class);
     }
 
     public function testFindReturnsCorrectValue(): void

--- a/test/Test/Bridge/Repository/PageRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PageRepositoryTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
 use Williarin\WordpressInterop\Bridge\Entity\Page;
-use Williarin\WordpressInterop\Bridge\Repository\PageRepository;
+use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Exception\EntityNotFoundException;
 use Williarin\WordpressInterop\Test\TestCase;
 
 class PageRepositoryTest extends TestCase
 {
-    private PageRepository $repository;
+    private EntityRepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new PageRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(Page::class);
     }
 
     public function testFindThrowsExceptionIfPostTypeDiffers(): void

--- a/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
-use Williarin\WordpressInterop\Bridge\Repository\PostMetaRepository;
+use Williarin\WordpressInterop\Bridge\Entity\PostMeta;
+use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
 use Williarin\WordpressInterop\Exception\PostMetaKeyAlreadyExistsException;
 use Williarin\WordpressInterop\Exception\PostMetaKeyNotFoundException;
 use Williarin\WordpressInterop\Test\TestCase;
 
 class PostMetaRepositoryTest extends TestCase
 {
-    private PostMetaRepository $repository;
+    private RepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new PostMetaRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(PostMeta::class);
     }
 
     public function testFindReturnsCorrectValue(): void

--- a/test/Test/Bridge/Repository/PostRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
 use Williarin\WordpressInterop\Bridge\Entity\Post;
-use Williarin\WordpressInterop\Bridge\Repository\PostRepository;
+use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Exception\EntityNotFoundException;
 use Williarin\WordpressInterop\Exception\InvalidFieldNameException;
 use Williarin\WordpressInterop\Exception\InvalidOrderByOrientationException;
@@ -13,12 +13,12 @@ use Williarin\WordpressInterop\Test\TestCase;
 
 class PostRepositoryTest extends TestCase
 {
-    private PostRepository $repository;
+    private EntityRepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new PostRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(Post::class);
     }
 
     public function testFindReturnsCorrectPost(): void

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
 use Williarin\WordpressInterop\Bridge\Entity\Product;
-use Williarin\WordpressInterop\Bridge\Repository\ProductRepository;
+use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Exception\EntityNotFoundException;
 use Williarin\WordpressInterop\Test\TestCase;
 
 class ProductRepositoryTest extends TestCase
 {
-    private ProductRepository $repository;
+    private EntityRepositoryInterface $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new ProductRepository($this->manager, $this->serializer);
+        $this->repository = $this->manager->getRepository(Product::class);
     }
 
     public function testFindReturnsCorrectProduct(): void


### PR DESCRIPTION
This PR allows repositories to be used as services.

While this library includes an EntityManager which creates new repository instances, it can be overriden in the service container.
See [williarin/wordpress-interop-bundle](https://github.com/williarin/wordpress-interop-bundle) for a use case example with a modified EntityManager.