### PR TITLE
Nested conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $allPosts = $postRepository->findAll();
 
 ## Documentation
 
-### Basic post querying
+### Basic querying
 
 This works with any entity inherited from `BaseEntity`.
 Built-in entities are `Post`, `Page`, `Attachment` and `Product` but you can [create your own](#create-your-own-repositories).
@@ -104,6 +104,24 @@ $posts = $manager->getRepository(Post::class)->findByPostStatus('private');
 // Fetch all products whose titles match regexp
 $products = $manager->getRepository(Product::class)
     ->findByPostTitle(new Operand('Hoodie.*Pocket|Zipper', Operand::OPERATOR_REGEXP));
+```
+
+### Complex querying
+
+For more complex querying needs, you can add nested conditions.
+
+_Note: it only works with columns and not EAV attributes._
+
+```php
+// Fetch Hoodies as well as products with at least 30 comments, all of which are in stock
+$products = $manager->getRepository(Product::class)
+    ->findBy([
+        new NestedCondition(NestedCondition::OPERATOR_OR, [
+            'post_title' => new Operand('Hoodie%', Operand::OPERATOR_LIKE),
+            'comment_count' => new Operand(30, Operand::OPERATOR_GREATER_THAN_OR_EQUAL),
+        ]),
+        'stock_status' => 'instock',
+    ]);
 ```
 
 ### EAV querying

--- a/src/Bridge/Repository/AttachmentRepository.php
+++ b/src/Bridge/Repository/AttachmentRepository.php
@@ -6,7 +6,7 @@ namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Attachment;
-use Williarin\WordpressInterop\Bridge\Type\Operand;
+use Williarin\WordpressInterop\Criteria\Operand;
 
 /**
  * @method Attachment   find($id)

--- a/src/Bridge/Repository/PageRepository.php
+++ b/src/Bridge/Repository/PageRepository.php
@@ -6,7 +6,7 @@ namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Page;
-use Williarin\WordpressInterop\Bridge\Type\Operand;
+use Williarin\WordpressInterop\Criteria\Operand;
 
 /**
  * @method Page   find($id)

--- a/src/Bridge/Repository/PostRepository.php
+++ b/src/Bridge/Repository/PostRepository.php
@@ -6,7 +6,7 @@ namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Post;
-use Williarin\WordpressInterop\Bridge\Type\Operand;
+use Williarin\WordpressInterop\Criteria\Operand;
 
 /**
  * @method Post   find($id)

--- a/src/Bridge/Repository/ProductRepository.php
+++ b/src/Bridge/Repository/ProductRepository.php
@@ -6,7 +6,7 @@ namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use DateTimeInterface;
 use Williarin\WordpressInterop\Bridge\Entity\Product;
-use Williarin\WordpressInterop\Bridge\Type\Operand;
+use Williarin\WordpressInterop\Criteria\Operand;
 
 /**
  * @method Product   find($id)

--- a/src/Criteria/NestedCondition.php
+++ b/src/Criteria/NestedCondition.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Criteria;
+
+final class NestedCondition
+{
+    public const OPERATOR_AND = 'and';
+    public const OPERATOR_OR = 'or';
+
+    public function __construct(
+        private string $operator,
+        private array $criteria
+    ) {
+    }
+
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    public function getCriteria(): array
+    {
+        return $this->criteria;
+    }
+}

--- a/src/Criteria/Operand.php
+++ b/src/Criteria/Operand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Williarin\WordpressInterop\Bridge\Type;
+namespace Williarin\WordpressInterop\Criteria;
 
 final class Operand
 {
@@ -30,5 +30,10 @@ final class Operand
     public function getOperator(): string
     {
         return $this->operator;
+    }
+
+    public function isLooseOperator(): bool
+    {
+        return in_array($this->operator, [self::OPERATOR_LIKE, self::OPERATOR_RLIKE, self::OPERATOR_REGEXP], true);
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Exception;
 
 use Exception;
-use Williarin\WordpressInterop\Bridge\Type\Operand;
+use Williarin\WordpressInterop\Criteria\Operand;
 
 final class EntityNotFoundException extends Exception
 {


### PR DESCRIPTION
Allow nested conditions with OR operator.

```php
// Fetch Hoodies as well as products with at least 30 comments, all of which are in stock
$products = $manager->getRepository(Product::class)
    ->findBy([
        new NestedCondition(NestedCondition::OPERATOR_OR, [
            'post_title' => new Operand('Hoodie%', Operand::OPERATOR_LIKE),
            'comment_count' => new Operand(30, Operand::OPERATOR_GREATER_THAN_OR_EQUAL),
        ]),
        'stock_status' => 'instock',
    ]);
```