### PR TITLE
Exception if option or postmeta doesn't exist during update

### DIFF
--- a/src/Bridge/Repository/OptionRepository.php
+++ b/src/Bridge/Repository/OptionRepository.php
@@ -110,10 +110,14 @@ class OptionRepository implements RepositoryInterface
         return $affectedRows > 0;
     }
 
-    public function update(string $optionName, mixed $optionValue): bool
+    public function update(string $optionName, mixed $optionValue, bool $throwExceptionIfNotFound = false): bool
     {
         if (is_array($optionValue)) {
             $optionValue = serialize($optionValue);
+        }
+
+        if ($throwExceptionIfNotFound) {
+            $this->find($optionName);
         }
 
         $affectedRows = $this->entityManager->getConnection()

--- a/src/Bridge/Repository/PostMetaRepository.php
+++ b/src/Bridge/Repository/PostMetaRepository.php
@@ -78,10 +78,14 @@ class PostMetaRepository implements RepositoryInterface
         return $affectedRows > 0;
     }
 
-    public function update(int $postId, string $metaKey, mixed $metaValue): bool
+    public function update(int $postId, string $metaKey, mixed $metaValue, bool $throwExceptionIfNotFound = false): bool
     {
         if (is_array($metaValue)) {
             $metaValue = serialize($metaValue);
+        }
+
+        if ($throwExceptionIfNotFound) {
+            $this->find($postId, $metaKey, false);
         }
 
         $affectedRows = $this->entityManager->getConnection()

--- a/test/Test/Bridge/Repository/OptionRepositoryTest.php
+++ b/test/Test/Bridge/Repository/OptionRepositoryTest.php
@@ -103,6 +103,12 @@ class OptionRepositoryTest extends TestCase
         self::assertFalse($this->repository->update('nonexistent_option', 'world'));
     }
 
+    public function testUpdateNonExistentOptionThrowsException(): void
+    {
+        $this->expectException(OptionNotFoundException::class);
+        $this->repository->update('nonexistent_option', 'world', true);
+    }
+
     public function testDeleteOptionWorks(): void
     {
         $this->repository->delete('an_option_to_delete');

--- a/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
@@ -86,6 +86,12 @@ class PostMetaRepositoryTest extends TestCase
         self::assertFalse($this->repository->update(5555, 'nonexistent_key', 'world'));
     }
 
+    public function testUpdateNonExistentKeyThrowsException(): void
+    {
+        $this->expectException(PostMetaKeyNotFoundException::class);
+        $this->repository->update(5555, 'nonexistent_key', 'world', true);
+    }
+
     public function testDeletePostMetaWorks(): void
     {
         $this->repository->delete(5, 'a_key_to_delete');


### PR DESCRIPTION
For both `OptionRepository` and `PostMetaRepository`, a new third argument `$throwExceptionIfNotFound`.

Example usage:
```php
$repository->update('my_option', 'my_value', true);
// => Exception thrown if my_option doesn't exist
```
