### PR TITLE
Query terms with post relationship condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ reset-woocommerce:
 	@$(CLI) wc shop_order create --user=1 --customer_id=0 --line_items='[{"product_id":20},{"product_id":22}]' \
 		--billing='{"first_name":"Trudie","last_name":"Metz","company":"Amazon","address_1":"135 Wyandot Ave","city":"Marion","state":"Ohio","postcode":"43302","country":"United States","email":"trudie@woo.local","phone":"(740) 383-4031"}' \
 		--shipping='{"first_name":"Trudie","last_name":"Metz","company":"Amazon","address_1":"135 Wyandot Ave","city":"Marion","state":"Ohio","postcode":"43302","country":"United States","email":"trudie@woo.local","phone":"(740) 383-4031"}'
+	@$(CLI) wc product_attribute create --name="Manufacturer" --user=1
+	@$(CLI) wc product_attribute_term create 1 --name="SuperBrand" --user=1
+	@$(CLI) wc product_attribute_term create 1 --name="MegaBrand" --user=1
+	@$(CLI) wc product create --name="Special Forces Hoodie" --description="Military hoodie with logo" \
+		--type=simple --regular_price=500 --user=1 --categories='[{"id": 17}]' --sku="super-forces-hoodie" \
+		--attributes='[{"name": "pa_manufacturer", "visible": true, "options": ["MegaBrand"]}]'
+	@$(CLI) post term add 64 pa_manufacturer megabrand
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,27 @@ $products = $manager->getRepository(Product::class)
     ]);
 ```
 
+### Post relationship conditions
+
+Query terms based on their posts relationships.
+
+```php
+// Fetch all terms of the product with SKU "super-forces-hoodie"
+// belonging to all taxonomies except "product_tag", "product_type", "product_visibility".
+$terms = $manager->getRepository(Term::class)
+    ->findBy([
+        new SelectColumns(['taxonomy', 'name']),
+        new PostRelationshipCondition(Product::class, [
+            'post_status' => new Operand(['publish', 'private'], Operand::OPERATOR_IN),
+            'sku' => 'super-forces-hoodie',
+        ]),
+        'taxonomy' => new Operand(
+            ['product_tag', 'product_type', 'product_visibility'],
+            Operand::OPERATOR_NOT_IN,
+        ),
+    ]);
+```
+
 ### Restrict selected columns
 
 Querying all columns at once is slow, especially if you have a lot of entities to retrieve.

--- a/src/Bridge/Repository/FieldValidationTrait.php
+++ b/src/Bridge/Repository/FieldValidationTrait.php
@@ -40,10 +40,20 @@ trait FieldValidationTrait
         return $expectedType->getName();
     }
 
-    private function validateFieldValue(string $field, mixed $value): mixed
+    private function validateFieldValue(string $field, mixed $value, string $entityClassName = null): mixed
     {
-        $fallbackEntity = get_parent_class(static::class) ?: static::class;
-        $expectedType = $this->validateFieldName($field, $fallbackEntity, static::TABLE_NAME);
+        if (!$entityClassName) {
+            $fallbackEntity = get_parent_class(static::class) ?: static::class;
+            $expectedType = $this->validateFieldName($field, $fallbackEntity, static::TABLE_NAME);
+        } else {
+            $expectedType = $this->validateFieldName(
+                $field,
+                $entityClassName,
+                (new \ReflectionClassConstant($this->entityManager->getRepository($entityClassName), 'TABLE_NAME'))
+                    ->getValue()
+            );
+        }
+
         $resolvedValue = $value instanceof Operand ? $value->getOperand() : $value;
 
         if ($value instanceof Operand && $value->isLooseOperator()) {

--- a/src/Bridge/Repository/NormalizerTrait.php
+++ b/src/Bridge/Repository/NormalizerTrait.php
@@ -8,6 +8,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Williarin\WordpressInterop\Criteria\NestedCondition;
 use Williarin\WordpressInterop\Criteria\Operand;
+use Williarin\WordpressInterop\Criteria\PostRelationshipCondition;
 use Williarin\WordpressInterop\Criteria\RelationshipCondition;
 use Williarin\WordpressInterop\Criteria\SelectColumns;
 use Williarin\WordpressInterop\Criteria\TermRelationshipCondition;
@@ -26,7 +27,7 @@ trait NormalizerTrait
         ]);
     }
 
-    protected function normalizeCriteria(array $criteria): array
+    protected function normalizeCriteria(array $criteria, string $entityClassName = null): array
     {
         $output = [];
 
@@ -36,13 +37,14 @@ trait NormalizerTrait
             } elseif (
                 $value instanceof RelationshipCondition
                 || $value instanceof TermRelationshipCondition
+                || $value instanceof PostRelationshipCondition
                 || $value instanceof SelectColumns
             ) {
                 $output[] = $value;
             } elseif ($value instanceof Operand && $value->isLooseOperator()) {
                 $output[$field] = $value->getOperand();
             } else {
-                $resolvedValue = $this->validateFieldValue($field, $value);
+                $resolvedValue = $this->validateFieldValue($field, $value, $entityClassName);
                 $output[$field] = (string) $this->serializer->normalize($resolvedValue);
             }
         }

--- a/src/Criteria/PostRelationshipCondition.php
+++ b/src/Criteria/PostRelationshipCondition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Criteria;
+
+final class PostRelationshipCondition
+{
+    public function __construct(
+        private string $entityClassName,
+        private array $criteria,
+    ) {
+    }
+
+    public function getEntityClassName(): string
+    {
+        return $this->entityClassName;
+    }
+
+    public function getCriteria(): array
+    {
+        return $this->criteria;
+    }
+}

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -46,7 +46,7 @@ class ProductRepositoryTest extends TestCase
     {
         $products = $this->repository->findAll();
         self::assertContainsOnlyInstancesOf(Product::class, $products);
-        self::assertCount(18, $products);
+        self::assertCount(19, $products);
     }
 
     public function testFindBySku(): void
@@ -82,13 +82,13 @@ class ProductRepositoryTest extends TestCase
             ['post_date' => 'DESC'],
         );
 
-        self::assertSame(37, $product->id);
+        self::assertSame(64, $product->id);
     }
     public function testFindAllPublishedProducts(): void
     {
         $products = $this->repository->findByPostStatus('publish');
         self::assertIsArray($products);
-        self::assertCount(18, $products);
+        self::assertCount(19, $products);
         self::assertContainsOnlyInstancesOf(Product::class, $products);
     }
 
@@ -235,7 +235,7 @@ class ProductRepositoryTest extends TestCase
             ]),
         ]);
         self::assertIsArray($products);
-        self::assertCount(18, $products);
+        self::assertCount(19, $products);
         self::assertContainsOnlyInstancesOf(Product::class, $products);
     }
 
@@ -248,13 +248,14 @@ class ProductRepositoryTest extends TestCase
             ]),
         ]);
         self::assertIsArray($products);
-        self::assertCount(4, $products);
+        self::assertCount(5, $products);
         self::assertContainsOnlyInstancesOf(Product::class, $products);
         self::assertEquals([
             'Hoodie',
             'Hoodie with Logo',
             'Hoodie with Pocket',
             'Hoodie with Zipper',
+            'Special Forces Hoodie',
         ], array_column($products, 'postTitle'));
     }
 


### PR DESCRIPTION
Example:

```php
// Fetch all terms of the product with SKU "super-forces-hoodie"
// belonging to all taxonomies except "product_tag", "product_type", "product_visibility".
$terms = $manager->getRepository(Term::class)
    ->findBy([
        new SelectColumns(['taxonomy', 'name']),
        new PostRelationshipCondition(Product::class, [
            'post_status' => new Operand(['publish', 'private'], Operand::OPERATOR_IN),
            'sku' => 'super-forces-hoodie',
        ]),
        'taxonomy' => new Operand(
            ['product_tag', 'product_type', 'product_visibility'],
            Operand::OPERATOR_NOT_IN,
        ),
    ]);
```