### PR TITLE
Validate prefixed and null fields

### DIFF
--- a/src/Util/String/StringUtil.php
+++ b/src/Util/String/StringUtil.php
@@ -30,20 +30,22 @@ function property_to_field(string $propertyName): string
 
 function field_to_property(string $fieldName): string
 {
-    return u($fieldName)
+    return u(($portion = strstr($fieldName, '.')) ? substr($portion, 1) : $fieldName)
         ->lower()
         ->camel()
         ->toString()
     ;
 }
 
-function select_from_eav(string $propertyName, ?string $metaKey = null, string $joinTableName = 'pm_self'): string
+function select_from_eav(string $fieldName, ?string $metaKey = null, string $joinTableName = 'pm_self'): string
 {
+    $fieldName = property_to_field($fieldName);
+
     return sprintf(
         "MAX(CASE WHEN %s.meta_key = '%s' THEN %s.meta_value END) `%s`",
         $joinTableName,
-        $metaKey ?? sprintf('_%s', ltrim($propertyName, '_')),
+        $metaKey ?? sprintf('_%s', ltrim($fieldName, '_')),
         $joinTableName,
-        $propertyName,
+        $fieldName,
     );
 }

--- a/test/Test/Util/String/FieldToPropertyTest.php
+++ b/test/Test/Util/String/FieldToPropertyTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Test\Util\String;
+
+use PHPUnit\Framework\TestCase;
+
+use function Williarin\WordpressInterop\Util\String\field_to_property;
+
+class FieldToPropertyTest extends TestCase
+{
+    public function testSnakeCase(): void
+    {
+        self::assertEquals('howAreYouToday', field_to_property('how_are_you_today'));
+    }
+
+    public function testPrefixedSnakeCase(): void
+    {
+        self::assertEquals('howAreYouToday', field_to_property('p0.how_are_you_today'));
+    }
+}

--- a/test/Test/Util/String/PropertyToFieldTest.php
+++ b/test/Test/Util/String/PropertyToFieldTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Test\Util\String;
+
+use PHPUnit\Framework\TestCase;
+
+use function Williarin\WordpressInterop\Util\String\property_to_field;
+
+class PropertyToFieldTest extends TestCase
+{
+    public function testCamelCase(): void
+    {
+        self::assertEquals('how_are_you_today', property_to_field('howAreYouToday'));
+    }
+
+    public function testSnakeCase(): void
+    {
+        self::assertEquals('how_are_you_today', property_to_field('how_are_you_today'));
+    }
+}

--- a/test/Test/Util/String/SelectFromEavTest.php
+++ b/test/Test/Util/String/SelectFromEavTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Test\Util\String;
+
+use PHPUnit\Framework\TestCase;
+
+use function Williarin\WordpressInterop\Util\String\select_from_eav;
+
+class SelectFromEavTest extends TestCase
+{
+    public function testSnakeCase(): void
+    {
+        self::assertEquals(
+            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) `product_attributes`",
+            select_from_eav('product_attributes'),
+        );
+    }
+
+    public function testCamelCase(): void
+    {
+        self::assertEquals(
+            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) `product_attributes`",
+            select_from_eav('productAttributes'),
+        );
+    }
+
+    public function testMetaKey(): void
+    {
+        self::assertEquals(
+            "MAX(CASE WHEN pm_self.meta_key = 'some_key' THEN pm_self.meta_value END) `product_attributes`",
+            select_from_eav('product_attributes', 'some_key'),
+        );
+    }
+
+    public function testJoinTableName(): void
+    {
+        self::assertEquals(
+            "MAX(CASE WHEN some_table.meta_key = 'some_key' THEN some_table.meta_value END) `product_attributes`",
+            select_from_eav('product_attributes', 'some_key', 'some_table'),
+        );
+    }
+}

--- a/test/Test/Util/String/UnserializeIfNeededTest.php
+++ b/test/Test/Util/String/UnserializeIfNeededTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Test\Util\String;
+
+use PHPUnit\Framework\TestCase;
+
+use function Williarin\WordpressInterop\Util\String\unserialize_if_needed;
+
+class UnserializeIfNeededTest extends TestCase
+{
+    public function testString(): void
+    {
+        self::assertEquals('this is a string', unserialize_if_needed('this is a string'));
+    }
+
+    public function testSerializedArray(): void
+    {
+        self::assertEquals(['hello' => 'world'], unserialize_if_needed(serialize(['hello' => 'world'])));
+    }
+}


### PR DESCRIPTION
This PR fixes two things:

1. Populating an entity won't fail anymore when the value is NULL and the entity property is nullable.
2. A prefixed field will be validated, for example `p0.post_title` will validate correctly with entity property `$postTitle`.