### PR TITLE
RelationshipCondition: allow Operand parameter and selectable relationship field

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,28 @@ $attachment = $manager->getRepository(Attachment::class)
     ->findOneBy([
         new RelationshipCondition(4, '_thumbnail_id'),
     ]);
+
+// Get featured images of posts 4, 13, 18 and 23 at once
+$attachments = $manager->getRepository(Attachment::class)
+    ->findBy([
+        new RelationshipCondition(
+            new Operand([4, 13, 18, 23], Operand::OPERATOR_IN),
+            '_thumbnail_id',
+        ),
+    ]);
+
+// Same as above example but include the original ID in the result
+$attachments = $manager->getRepository(Attachment::class)
+    ->findBy([
+        new RelationshipCondition(
+            new Operand([4, 13, 18, 23], Operand::OPERATOR_IN),
+            '_thumbnail_id',
+            'original_post_id',
+        ),
+    ]);
+// $attachments[0]->originalPostId === 4
 ```
+
 
 ### Term and taxonomy relationship conditions
 

--- a/src/Criteria/RelationshipCondition.php
+++ b/src/Criteria/RelationshipCondition.php
@@ -4,21 +4,43 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Criteria;
 
+use JetBrains\PhpStorm\Deprecated;
+use Williarin\WordpressInterop\Exception\RelationshipIdDeprecationException;
+
 final class RelationshipCondition
 {
     public function __construct(
-        private int $relationshipId,
-        private string $relationshipFieldName
+        private int|Operand $relationshipIdOrOperand,
+        private string $relationshipFieldName,
+        private ?string $alias = null,
     ) {
     }
 
+    #[Deprecated(
+        reason: 'Since 1.8.0, use getRelationshipIdOrOperand() instead',
+        replacement: '%class%->getRelationshipIdOrOperand()'
+    )]
     public function getRelationshipId(): int
     {
-        return $this->relationshipId;
+        if (is_int($this->relationshipIdOrOperand)) {
+            return $this->relationshipIdOrOperand;
+        }
+
+        throw new RelationshipIdDeprecationException();
+    }
+
+    public function getRelationshipIdOrOperand(): int|Operand
+    {
+        return $this->relationshipIdOrOperand;
     }
 
     public function getRelationshipFieldName(): string
     {
         return $this->relationshipFieldName;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->alias;
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -29,7 +29,7 @@ final class EntityNotFoundException extends Exception
         return implode(', ', array_filter(array_map(
             function (mixed $value, int|string $field): string {
                 $field = $value instanceof RelationshipCondition
-                    ? sprintf('relationship ID "%s"', $value->getRelationshipId())
+                    ? sprintf('relationship ID "%s"', $value->getRelationshipIdOrOperand())
                     : $field;
 
                 if ($value instanceof Operand) {

--- a/src/Exception/RelationshipIdDeprecationException.php
+++ b/src/Exception/RelationshipIdDeprecationException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Exception;
+
+final class RelationshipIdDeprecationException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            "This method is deprecated and can't be used with an Operand parameter. " .
+            'Use `RelationshipCondition::getRelationshipIdOrOperand()` instead.'
+        );
+    }
+}

--- a/src/Util/String/StringUtil.php
+++ b/src/Util/String/StringUtil.php
@@ -42,7 +42,7 @@ function select_from_eav(string $fieldName, ?string $metaKey = null, string $joi
     $fieldName = property_to_field($fieldName);
 
     return sprintf(
-        "MAX(CASE WHEN %s.meta_key = '%s' THEN %s.meta_value END) `%s`",
+        "MAX(CASE WHEN %s.meta_key = '%s' THEN %s.meta_value END) AS `%s`",
         $joinTableName,
         $metaKey ?? sprintf('_%s', ltrim($fieldName, '_')),
         $joinTableName,

--- a/test/Test/Bridge/Repository/AttachmentRepositoryTest.php
+++ b/test/Test/Bridge/Repository/AttachmentRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
 use Williarin\WordpressInterop\Bridge\Entity\Attachment;
 use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
+use Williarin\WordpressInterop\Criteria\Operand;
 use Williarin\WordpressInterop\Criteria\RelationshipCondition;
 use Williarin\WordpressInterop\Test\TestCase;
 
@@ -37,5 +38,31 @@ class AttachmentRepositoryTest extends TestCase
             new RelationshipCondition(4, '_thumbnail_id'),
         ]);
         self::assertEquals(sprintf('%s/featuredimage.png', date('Y/m')), $attachment->attachedFile);
+    }
+
+    public function testGetFeaturedImageUsingRelationshipConditionWithPostId(): void
+    {
+        $attachment = $this->repository->findOneBy([
+            new RelationshipCondition(4, '_thumbnail_id', 'original_post_id'),
+        ]);
+        self::assertEquals(4, $attachment->originalPostId);
+    }
+
+    public function testGetFeaturedImagesOfMultiplePosts(): void
+    {
+        $attachments = $this->repository->findBy([
+            new RelationshipCondition(
+                new Operand([4, 13, 18, 23], Operand::OPERATOR_IN),
+                '_thumbnail_id',
+                'original_post_id',
+            ),
+        ]);
+        self::assertEquals([
+            '2022/06/featuredimage.png',
+            '2019/01/beanie-2.jpg',
+            '2019/01/hoodie-with-zipper-2.jpg',
+        ], array_column($attachments, 'attachedFile'));
+
+        self::assertEquals([4, 18, 23], array_column($attachments, 'originalPostId'));
     }
 }

--- a/test/Test/Util/String/SelectFromEavTest.php
+++ b/test/Test/Util/String/SelectFromEavTest.php
@@ -13,7 +13,7 @@ class SelectFromEavTest extends TestCase
     public function testSnakeCase(): void
     {
         self::assertEquals(
-            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) `product_attributes`",
+            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) AS `product_attributes`",
             select_from_eav('product_attributes'),
         );
     }
@@ -21,7 +21,7 @@ class SelectFromEavTest extends TestCase
     public function testCamelCase(): void
     {
         self::assertEquals(
-            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) `product_attributes`",
+            "MAX(CASE WHEN pm_self.meta_key = '_product_attributes' THEN pm_self.meta_value END) AS `product_attributes`",
             select_from_eav('productAttributes'),
         );
     }
@@ -29,7 +29,7 @@ class SelectFromEavTest extends TestCase
     public function testMetaKey(): void
     {
         self::assertEquals(
-            "MAX(CASE WHEN pm_self.meta_key = 'some_key' THEN pm_self.meta_value END) `product_attributes`",
+            "MAX(CASE WHEN pm_self.meta_key = 'some_key' THEN pm_self.meta_value END) AS `product_attributes`",
             select_from_eav('product_attributes', 'some_key'),
         );
     }
@@ -37,7 +37,7 @@ class SelectFromEavTest extends TestCase
     public function testJoinTableName(): void
     {
         self::assertEquals(
-            "MAX(CASE WHEN some_table.meta_key = 'some_key' THEN some_table.meta_value END) `product_attributes`",
+            "MAX(CASE WHEN some_table.meta_key = 'some_key' THEN some_table.meta_value END) AS `product_attributes`",
             select_from_eav('product_attributes', 'some_key', 'some_table'),
         );
     }


### PR DESCRIPTION
This PR introduces two new features

### Operand as parameter
This allows to query multiple relationships at once.

Example:
```php
// Get featured images of posts 4, 13, 18 and 23 at once
$attachments = $manager->getRepository(Attachment::class)
    ->findBy([
        new RelationshipCondition(
            new Operand([4, 13, 18, 23], Operand::OPERATOR_IN),
            '_thumbnail_id',
        ),
    ]);
```

### Add relationship ID to SELECT clause
Example:
```php
$attachments = $manager->getRepository(Attachment::class)
    ->findBy([
        new RelationshipCondition(
            new Operand([4, 13, 18, 23], Operand::OPERATOR_IN),
            '_thumbnail_id',
            'original_post_id',
        ),
    ]);
// $attachments[0]->originalPostId === 4
```
