### PR TITLE
Allow null parameter for unserialize_if_needed function

### DIFF
--- a/src/Util/String/StringUtil.php
+++ b/src/Util/String/StringUtil.php
@@ -6,8 +6,12 @@ namespace Williarin\WordpressInterop\Util\String;
 
 use function Symfony\Component\String\u;
 
-function unserialize_if_needed(string $data): string|array
+function unserialize_if_needed(?string $data): string|array|null
 {
+    if ($data === null) {
+        return null;
+    }
+
     $unserialized = @unserialize($data, [
         'allowed_classes' => [],
     ]);

--- a/test/Test/Util/String/UnserializeIfNeededTest.php
+++ b/test/Test/Util/String/UnserializeIfNeededTest.php
@@ -19,4 +19,9 @@ class UnserializeIfNeededTest extends TestCase
     {
         self::assertEquals(['hello' => 'world'], unserialize_if_needed(serialize(['hello' => 'world'])));
     }
+
+    public function testNull(): void
+    {
+        self::assertNull(unserialize_if_needed(null));
+    }
 }


### PR DESCRIPTION
Allow null parameter.

```php
unserialize_if_needed(null) === null // true
```
