### PR TITLE
Entity duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,21 @@ $repository->persist($post);
 $manager->persist($post);
 ```
 
+### Entity duplication
+Duplicate an entity with all its EAV attributes and terms with `DuplicationService`.
+The resulting entity is already persisted and has a new ID.
+
+```php
+$duplicationService = new DuplicationService($entityManager, new AsciiSlugger();
+
+// Duplicate by ID
+$newProduct =  $this->duplicationService->duplicate(23, Product::class);
+
+// Duplicate by object
+$product = $manager->getRepository(Product::class)->findOneBySku('woo-hoodie-with-zipper');
+$newProduct =  $this->duplicationService->duplicate($product);
+```
+
 ### Available entities and repositories
 
 * `Post` and `PostRepository`

--- a/src/Attributes/Slug.php
+++ b/src/Attributes/Slug.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Attributes;
+
+use Attribute;
+
+/**
+ * Mark the property as slug. When duplicating an entity, all slug properties will be slugged.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Slug
+{
+}

--- a/src/Attributes/Unique.php
+++ b/src/Attributes/Unique.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Attributes;
+
+use Attribute;
+
+/**
+ * Mark the property as unique. When duplicating an entity, all unique properties will have a suffix appended.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Unique
+{
+}

--- a/src/Bridge/Entity/BaseEntity.php
+++ b/src/Bridge/Entity/BaseEntity.php
@@ -6,9 +6,13 @@ namespace Williarin\WordpressInterop\Bridge\Entity;
 
 use DateTimeInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Williarin\WordpressInterop\Attributes\Slug;
+use Williarin\WordpressInterop\Attributes\Unique;
 
 abstract class BaseEntity
 {
+    use DynamicPropertiesTrait;
+
     #[Groups('base')]
     public ?int $id = null;
 
@@ -24,6 +28,7 @@ abstract class BaseEntity
     #[Groups('base')]
     public ?string $postContent = null;
 
+    #[Unique]
     #[Groups('base')]
     public ?string $postTitle = null;
 
@@ -42,6 +47,7 @@ abstract class BaseEntity
     #[Groups('base')]
     public ?string $postPassword = null;
 
+    #[Unique, Slug]
     #[Groups('base')]
     public ?string $postName = null;
 
@@ -77,24 +83,4 @@ abstract class BaseEntity
 
     #[Groups('base')]
     public ?int $commentCount = null;
-
-    public function __set(string $property, mixed $value): void
-    {
-        if ($value === '' && !is_string($this->{$property})) {
-            return;
-        }
-
-        try {
-            $expectedType = (new \ReflectionProperty(static::class, $property))->getType()->getName();
-            settype($value, $expectedType);
-        } catch (\ReflectionException) {
-        }
-
-        $this->{$property} = $value;
-    }
-
-    public function __get(string $property): mixed
-    {
-        return $this->{$property};
-    }
 }

--- a/src/Bridge/Entity/DynamicPropertiesTrait.php
+++ b/src/Bridge/Entity/DynamicPropertiesTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Bridge\Entity;
+
+trait DynamicPropertiesTrait
+{
+    public function __set(string $property, mixed $value): void
+    {
+        if ($value === '' && !is_string($this->{$property})) {
+            return;
+        }
+
+        try {
+            $expectedType = (new \ReflectionProperty(static::class, $property))->getType()->getName();
+            settype($value, $expectedType);
+        } catch (\ReflectionException) {
+        }
+
+        $this->{$property} = $value;
+    }
+
+    public function __get(string $property): mixed
+    {
+        return $this->{$property};
+    }
+}

--- a/src/Bridge/Entity/PostMeta.php
+++ b/src/Bridge/Entity/PostMeta.php
@@ -10,4 +10,8 @@ use Williarin\WordpressInterop\Bridge\Repository\PostMetaRepository;
 #[RepositoryClass(PostMetaRepository::class)]
 class PostMeta
 {
+//    public ?int $metaId = null;
+//    public ?int $postId = null;
+//    public ?string $metaKey = null;
+//    public string|array|int|float|bool|null $metaValue = null;
 }

--- a/src/Bridge/Entity/Product.php
+++ b/src/Bridge/Entity/Product.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Entity;
 
 use Williarin\WordpressInterop\Attributes\RepositoryClass;
+use Williarin\WordpressInterop\Attributes\Slug;
+use Williarin\WordpressInterop\Attributes\Unique;
 use Williarin\WordpressInterop\Bridge\Repository\ProductRepository;
 use Williarin\WordpressInterop\Bridge\Type\GenericData;
 
@@ -22,6 +24,7 @@ use Williarin\WordpressInterop\Bridge\Type\GenericData;
 #[RepositoryClass(ProductRepository::class)]
 class Product extends BaseEntity
 {
+    #[Unique, Slug]
     public ?string $sku = null;
     public ?string $taxStatus = null;
     public ?string $taxClass = null;

--- a/src/Bridge/Entity/Term.php
+++ b/src/Bridge/Entity/Term.php
@@ -13,6 +13,8 @@ use Williarin\WordpressInterop\Bridge\Repository\TermRepository;
 #[RepositoryClass(TermRepository::class)]
 class Term
 {
+    use DynamicPropertiesTrait;
+
     #[Id]
     #[Groups('base')]
     public ?int $termId = null;

--- a/src/Bridge/Repository/EntityRepositoryInterface.php
+++ b/src/Bridge/Repository/EntityRepositoryInterface.php
@@ -21,4 +21,6 @@ interface EntityRepositoryInterface extends RepositoryInterface
     public function updateSingleField(int $id, string $field, mixed $newValue): bool;
 
     public function persist(mixed $entity): void;
+
+    public function getMetaEntityClassName(): string;
 }

--- a/src/Persistence/DuplicationService.php
+++ b/src/Persistence/DuplicationService.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Persistence;
+
+use Symfony\Component\String\Slugger\SluggerInterface;
+use Williarin\WordpressInterop\Attributes\Slug;
+use Williarin\WordpressInterop\Attributes\Unique;
+use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
+use Williarin\WordpressInterop\Bridge\Entity\Product;
+use Williarin\WordpressInterop\Bridge\Entity\Term;
+use Williarin\WordpressInterop\Criteria\PostRelationshipCondition;
+use Williarin\WordpressInterop\EntityManagerInterface;
+use Williarin\WordpressInterop\Exception\MissingEntityTypeException;
+use function Williarin\WordpressInterop\Util\String\property_to_field;
+
+final class DuplicationService
+{
+    public const POST_STATUS_DRAFT = 'draft';
+    public const POST_STATUS_PRIVATE = 'private';
+    public const POST_STATUS_PUBLISH = 'publish';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private SluggerInterface $slugger,
+    ) {
+    }
+
+    public function duplicate(
+        BaseEntity|int $entityOrId,
+        ?string $entityType = null,
+        string $postStatus = self::POST_STATUS_DRAFT,
+        string $suffix = ' (Copy)',
+    ): BaseEntity {
+        if (is_int($entityOrId)) {
+            if ($entityType === null) {
+                throw new MissingEntityTypeException();
+            }
+
+            $entity = $this->entityManager->getRepository($entityType)
+                ->find($entityOrId)
+            ;
+        } else {
+            $entity = $entityOrId;
+        }
+
+        $clone = clone $entity;
+        $clone->id = null;
+
+        $properties = $this->getClassPropertyAttributes($clone, BaseEntity::class, $suffix);
+
+        foreach ($properties as $property => $attributes) {
+            $entity->{$property} .= \in_array(Slug::class, $attributes, true)
+                ? '-' . $this->slugger->slug($suffix)
+                    ->lower()
+                    ->toString()
+                : $suffix
+            ;
+        }
+
+        $this->entityManager->persist($clone);
+        $this->duplicateMeta($entity, $clone, $suffix);
+        $this->duplicateTerms($entity, $clone);
+
+        return $clone;
+    }
+
+    private function duplicateMeta(BaseEntity $entity, BaseEntity &$clone, string $suffix): void
+    {
+        $repository = $this->entityManager->getRepository($entity::class);
+        $metaRepository = $this->entityManager->getRepository($repository->getMetaEntityClassName());
+
+        $postMetas = $metaRepository->findBy($entity->id, false);
+
+        $properties = $this->getClassPropertyAttributes($clone, Product::class, $suffix);
+
+        foreach ($properties as $property => $attributes) {
+            $metaKey = $repository->getMappedMetaKey(property_to_field($property));
+
+            $postMetas[$metaKey] .= \in_array(Slug::class, $attributes, true)
+                ? '-' . $this->slugger->slug($suffix)
+                    ->lower()
+                    ->toString()
+                : $suffix
+            ;
+        }
+
+        foreach ($postMetas as $key => $value) {
+            $metaRepository->create($clone->id, $key, $value);
+        }
+
+        $clone = $repository->find($clone->id);
+    }
+
+    private function duplicateTerms(BaseEntity $entity, BaseEntity $clone): void
+    {
+        $termRepository = $this->entityManager->getRepository(Term::class);
+        $terms = $termRepository->findBy([
+            new PostRelationshipCondition(Product::class, [
+                'id' => $entity->id,
+            ]),
+        ]);
+
+        $termRepository->addTermsToEntity($clone, $terms);
+    }
+
+    private function getClassPropertyAttributes(BaseEntity $entity, string $className, string $suffix): array
+    {
+        $properties = [];
+
+        foreach ((new \ReflectionClass($entity::class))->getProperties() as $property) {
+            if ($property->class !== $className) {
+                continue;
+            }
+
+            if (\count($property->getAttributes(Unique::class)) > 0) {
+                $properties[$property->getName()] = [Unique::class];
+            }
+
+            if (\count($property->getAttributes(Slug::class)) > 0) {
+                $properties[$property->getName()][] = Slug::class;
+            }
+        }
+
+        return $properties;
+    }
+}

--- a/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostMetaRepositoryTest.php
@@ -107,4 +107,53 @@ class PostMetaRepositoryTest extends TestCase
     {
         self::assertFalse($this->repository->update(4444, 'another_nonexistent_key', 'hello'));
     }
+
+    public function testFindBy(): void
+    {
+        $postMetas = $this->repository->findBy(23);
+
+        self::assertEquals([
+            '_sku' => 'woo-hoodie-with-zipper',
+            '_regular_price' => '45',
+            '_sale_price' => '',
+            '_sale_price_dates_from' => '',
+            '_sale_price_dates_to' => '',
+            'total_sales' => '0',
+            '_tax_status' => 'taxable',
+            '_tax_class' => '',
+            '_manage_stock' => 'no',
+            '_backorders' => 'no',
+            '_low_stock_amount' => '',
+            '_sold_individually' => 'no',
+            '_weight' => '2',
+            '_length' => '8',
+            '_width' => '6',
+            '_height' => '2',
+            '_upsell_ids' => [],
+            '_crosssell_ids' => [],
+            '_purchase_note' => '',
+            '_default_attributes' => [],
+            '_virtual' => 'no',
+            '_downloadable' => 'no',
+            '_product_image_gallery' => '',
+            '_download_limit' => '0',
+            '_download_expiry' => '0',
+            '_stock' => '',
+            '_stock_status' => 'instock',
+            '_wc_average_rating' => '0',
+            '_wc_rating_count' => [],
+            '_wc_review_count' => '0',
+            '_downloadable_files' => [],
+            '_product_attributes' => [],
+            '_product_version' => '3.5.3',
+            '_price' => '45',
+            '_thumbnail_id' => '52',
+        ], $postMetas);
+    }
+
+    public function testFindByWithNoResult(): void
+    {
+        $postMetas = $this->repository->findBy(100);
+        self::assertEquals([], $postMetas);
+    }
 }

--- a/test/Test/Manipulation/DuplicationServiceTest.php
+++ b/test/Test/Manipulation/DuplicationServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Test\Manipulation;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Williarin\WordpressInterop\Bridge\Entity\Product;
+use Williarin\WordpressInterop\Bridge\Entity\Term;
+use Williarin\WordpressInterop\Criteria\PostRelationshipCondition;
+use Williarin\WordpressInterop\Exception\MissingEntityTypeException;
+use Williarin\WordpressInterop\Persistence\DuplicationService;
+use Williarin\WordpressInterop\Test\TestCase;
+
+class DuplicationServiceTest extends TestCase
+{
+    private DuplicationService $duplicationService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->duplicationService = new DuplicationService($this->manager, new AsciiSlugger());
+    }
+
+    public function testDuplicateByIdWithoutEntityClassNameThrowsException(): void
+    {
+        $this->expectException(MissingEntityTypeException::class);
+        $this->duplicationService->duplicate(23);
+    }
+
+    public function testDuplicateById(): void
+    {
+        $newEntity = $this->duplicationService->duplicate(23, Product::class);
+        $originalTerms = $this->manager->getRepository(Term::class)
+            ->findBy([
+                new PostRelationshipCondition(Product::class, ['id' => 23]),
+            ]);
+
+        $newTerms = $this->manager->getRepository(Term::class)
+            ->findBy([
+                new PostRelationshipCondition(Product::class, ['id' => $newEntity->id]),
+            ]);
+
+        self::assertNotSame(23, $newEntity->id);
+        self::assertIsNumeric($newEntity->id);
+        self::assertSame($newEntity->sku, 'woo-hoodie-with-zipper-copy');
+        self::assertSame(array_column($originalTerms, 'name'), array_column($newTerms, 'name'));
+        self::assertEquals($originalTerms, $newTerms);
+    }
+
+    public function testDuplicateByEntity(): void
+    {
+        $product = $this->manager->getRepository(Product::class)
+            ->findOneBySku('woo-hoodie-with-zipper');
+
+        $newEntity = $this->duplicationService->duplicate($product);
+
+        $originalTerms = $this->manager->getRepository(Term::class)
+            ->findBy([
+                new PostRelationshipCondition(Product::class, ['id' => $product->id]),
+            ]);
+
+        $newTerms = $this->manager->getRepository(Term::class)
+            ->findBy([
+                new PostRelationshipCondition(Product::class, ['id' => $newEntity->id]),
+            ]);
+
+        self::assertNotSame($product->id, $newEntity->id);
+        self::assertIsNumeric($newEntity->id);
+        self::assertSame($newEntity->sku, 'woo-hoodie-with-zipper-copy');
+        self::assertSame(array_column($originalTerms, 'name'), array_column($newTerms, 'name'));
+        self::assertEquals($originalTerms, $newTerms);
+    }
+}


### PR DESCRIPTION
Duplicate an entity with all its EAV attributes and terms with `DuplicationService`.
The resulting entity is already persisted and has a new ID.

```php
$duplicationService = new DuplicationService($entityManager, new AsciiSlugger();

// Duplicate by ID
$newProduct =  $this->duplicationService->duplicate(23, Product::class);

// Duplicate by object
$product = $manager->getRepository(Product::class)->findOneBySku('woo-hoodie-with-zipper');
$newProduct =  $this->duplicationService->duplicate($product);
```