### PR TITLE
Retrieve `DuplicationService` from the manager registry or manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,14 +316,14 @@ Duplicate an entity with all its EAV attributes and terms with `DuplicationServi
 The resulting entity is already persisted and has a new ID.
 
 ```php
-$duplicationService = new DuplicationService($entityManager, new AsciiSlugger();
+$duplicationService = $manager->getDuplicationService();
 
 // Duplicate by ID
-$newProduct =  $this->duplicationService->duplicate(23, Product::class);
+$newProduct =  $duplicationService->duplicate(23, Product::class);
 
 // Duplicate by object
 $product = $manager->getRepository(Product::class)->findOneBySku('woo-hoodie-with-zipper');
-$newProduct =  $this->duplicationService->duplicate($product);
+$newProduct =  $duplicationService->duplicate($product);
 ```
 
 ### Available entities and repositories

--- a/src/AbstractEntityManager.php
+++ b/src/AbstractEntityManager.php
@@ -7,9 +7,12 @@ namespace Williarin\WordpressInterop;
 use Doctrine\DBAL\Connection;
 use ReflectionClass;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Williarin\WordpressInterop\Attributes\RepositoryClass;
 use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
 use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
+use Williarin\WordpressInterop\Persistence\DuplicationService;
+use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
 
 abstract class AbstractEntityManager implements EntityManagerInterface
 {
@@ -18,7 +21,8 @@ abstract class AbstractEntityManager implements EntityManagerInterface
     public function __construct(
         private Connection $connection,
         protected SerializerInterface $serializer,
-        private string $tablePrefix = 'wp_'
+        private string $tablePrefix = 'wp_',
+        protected ?DuplicationServiceInterface $duplicationService = null,
     ) {
     }
 
@@ -46,6 +50,17 @@ abstract class AbstractEntityManager implements EntityManagerInterface
         $this->repositories[$entityClassName]->setEntityManager($this);
 
         return $this->repositories[$entityClassName];
+    }
+
+    public function getDuplicationService(): DuplicationServiceInterface
+    {
+        if (!$this->duplicationService) {
+            $this->duplicationService = new DuplicationService(new AsciiSlugger());
+        }
+
+        $this->duplicationService->setEntityManager($this);
+
+        return $this->duplicationService;
     }
 
     public function getConnection(): Connection

--- a/src/AbstractManagerRegistry.php
+++ b/src/AbstractManagerRegistry.php
@@ -6,6 +6,7 @@ namespace Williarin\WordpressInterop;
 
 use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
 use Williarin\WordpressInterop\Exception\InvalidArgumentException;
+use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
 
 abstract class AbstractManagerRegistry implements ManagerRegistryInterface
 {
@@ -60,6 +61,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistryInterface
         return $this
             ->getManager($managerName)
             ->getRepository($entityClassName)
+        ;
+    }
+
+    public function getDuplicationService(?string $managerName = null): DuplicationServiceInterface
+    {
+        return $this
+            ->getManager($managerName)
+            ->getDuplicationService()
         ;
     }
 

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -6,6 +6,7 @@ namespace Williarin\WordpressInterop;
 
 use Doctrine\DBAL\Connection;
 use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
+use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
 
 interface EntityManagerInterface
 {
@@ -18,4 +19,6 @@ interface EntityManagerInterface
     public function getRepository(string $entityClassName): RepositoryInterface;
 
     public function getTablesPrefix(): string;
+
+    public function getDuplicationService(): DuplicationServiceInterface;
 }

--- a/src/Exception/EntityManagerNotSetException.php
+++ b/src/Exception/EntityManagerNotSetException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Exception;
+
+final class EntityManagerNotSetException extends \RuntimeException
+{
+    public function __construct(string $owningClass)
+    {
+        parent::__construct(sprintf('You must call %s::setEntityManager() before use.', $owningClass));
+    }
+}

--- a/src/Persistence/DuplicationServiceInterface.php
+++ b/src/Persistence/DuplicationServiceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Persistence;
+
+use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
+use Williarin\WordpressInterop\EntityManagerAwareInterface;
+
+interface DuplicationServiceInterface extends EntityManagerAwareInterface
+{
+    public const POST_STATUS_DRAFT = 'draft';
+    public const POST_STATUS_PRIVATE = 'private';
+    public const POST_STATUS_PUBLISH = 'publish';
+
+    public function duplicate(
+        BaseEntity|int $entityOrId,
+        ?string $entityType = null,
+        string $postStatus = self::POST_STATUS_DRAFT,
+        string $suffix = ' (Copy)',
+    ): BaseEntity;
+}

--- a/test/Test/ManagerRegistryTest.php
+++ b/test/Test/ManagerRegistryTest.php
@@ -11,6 +11,7 @@ use Williarin\WordpressInterop\Bridge\Entity\Product;
 use Williarin\WordpressInterop\Bridge\Repository\ProductRepository;
 use Williarin\WordpressInterop\EntityManagerInterface;
 use Williarin\WordpressInterop\Exception\InvalidArgumentException;
+use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
 
 class ManagerRegistryTest extends TestCase
 {
@@ -63,6 +64,17 @@ class ManagerRegistryTest extends TestCase
     public function testGetRepository(): void
     {
         self::assertInstanceOf(ProductRepository::class, $this->managerRegistry->getRepository(Product::class));
+    }
+
+    public function testGetDefaultDuplicationService(): void
+    {
+        self::assertInstanceOf(DuplicationServiceInterface::class, $this->managerRegistry->getDuplicationService());
+    }
+
+    public function testGetNonExistentDuplicationService(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->managerRegistry->getDuplicationService('fr');
     }
 
     private function getManagerFactory(): Closure

--- a/test/Test/Persistence/DuplicationServiceTest.php
+++ b/test/Test/Persistence/DuplicationServiceTest.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Williarin\WordpressInterop\Test\Manipulation;
+namespace Williarin\WordpressInterop\Test\Persistence;
 
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Williarin\WordpressInterop\Bridge\Entity\Product;
 use Williarin\WordpressInterop\Bridge\Entity\Term;
 use Williarin\WordpressInterop\Criteria\PostRelationshipCondition;
+use Williarin\WordpressInterop\Exception\EntityManagerNotSetException;
 use Williarin\WordpressInterop\Exception\MissingEntityTypeException;
 use Williarin\WordpressInterop\Persistence\DuplicationService;
 use Williarin\WordpressInterop\Test\TestCase;
@@ -19,13 +20,20 @@ class DuplicationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->duplicationService = new DuplicationService($this->manager, new AsciiSlugger());
+        $this->duplicationService = $this->manager->getDuplicationService();
     }
 
     public function testDuplicateByIdWithoutEntityClassNameThrowsException(): void
     {
         $this->expectException(MissingEntityTypeException::class);
         $this->duplicationService->duplicate(23);
+    }
+
+    public function testEntityManagerNotSet(): void
+    {
+        $this->expectException(EntityManagerNotSetException::class);
+        $duplicationService = new DuplicationService(new AsciiSlugger());
+        $duplicationService->duplicate(23);
     }
 
     public function testDuplicateById(): void


### PR DESCRIPTION
This PR introduces a change from the previous commit 020d04f.

Now instead of building the `DuplicationService` class by injecting the EntityManager, we retrieve the service through the EntityManager instance.

Before:
```php
$duplicationService = new DuplicationService($entityManager, new AsciiSlugger();
```

After:
```php
$duplicationService = $entityManager->getDuplicationService();
```