### PR TITLE
Make entities integer properties protected in order to cast them when denormalizing

### DIFF
--- a/src/Bridge/Entity/Page.php
+++ b/src/Bridge/Entity/Page.php
@@ -7,8 +7,11 @@ namespace Williarin\WordpressInterop\Bridge\Entity;
 use Williarin\WordpressInterop\Attributes\RepositoryClass;
 use Williarin\WordpressInterop\Bridge\Repository\PageRepository;
 
+/**
+ * @property ?int $thumbnailId
+ */
 #[RepositoryClass(PageRepository::class)]
 class Page extends BaseEntity
 {
-    public ?int $thumbnailId = null;
+    protected ?int $thumbnailId = null;
 }

--- a/src/Bridge/Entity/Post.php
+++ b/src/Bridge/Entity/Post.php
@@ -7,8 +7,11 @@ namespace Williarin\WordpressInterop\Bridge\Entity;
 use Williarin\WordpressInterop\Attributes\RepositoryClass;
 use Williarin\WordpressInterop\Bridge\Repository\PostRepository;
 
+/**
+ * @property ?int $thumbnailId
+ */
 #[RepositoryClass(PostRepository::class)]
 class Post extends BaseEntity
 {
-    public ?int $thumbnailId = null;
+    protected ?int $thumbnailId = null;
 }

--- a/src/Bridge/Entity/Product.php
+++ b/src/Bridge/Entity/Product.php
@@ -11,6 +11,7 @@ use Williarin\WordpressInterop\Bridge\Repository\ProductRepository;
 use Williarin\WordpressInterop\Bridge\Type\GenericData;
 
 /**
+ * @property ?int   $thumbnailId
  * @property ?int   $downloadExpiry
  * @property ?int   $downloadLimit
  * @property ?int   $salePriceDatesFrom
@@ -20,6 +21,8 @@ use Williarin\WordpressInterop\Bridge\Type\GenericData;
  * @property ?float $length
  * @property ?float $width
  * @property ?float $height
+ * @property ?int   $reviewCount
+ * @property ?int   $averageRating
  */
 #[RepositoryClass(ProductRepository::class)]
 class Product extends BaseEntity
@@ -41,13 +44,10 @@ class Product extends BaseEntity
     public ?string $productImageGallery = null;
     public ?string $stock = null;
     public ?string $stockStatus = null;
-    public ?int $averageRating = null;
     public ?GenericData $ratingCount = null;
-    public ?int $reviewCount = null;
     public ?GenericData $downloadableFiles = null;
     public ?GenericData $productAttributes = null;
     public ?string $productVersion = null;
-    public ?int $thumbnailId = null;
     public ?string $price = null;
     public ?string $regularPrice = null;
     public ?string $salePrice = null;
@@ -60,4 +60,7 @@ class Product extends BaseEntity
     protected ?float $length = null;
     protected ?float $width = null;
     protected ?float $height = null;
+    protected ?int $thumbnailId = null;
+    protected ?int $reviewCount = null;
+    protected ?int $averageRating = null;
 }

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 
+use Williarin\WordpressInterop\Bridge\Entity\PostMeta;
 use Williarin\WordpressInterop\Bridge\Entity\Product;
 use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Criteria\NestedCondition;
@@ -355,5 +356,15 @@ class ProductRepositoryTest extends TestCase
         $expected->category = 'Hoodies';
 
         self::assertEquals($expected, $product);
+    }
+
+    public function testEmptyStringForIntEAVRetrieval(): void
+    {
+        $this->manager->getRepository(PostMeta::class)
+            ->update(14, '_thumbnail_id', '')
+        ;
+
+        $product = $this->repository->find(14);
+        self::assertNull($product->thumbnailId);
     }
 }


### PR DESCRIPTION
Fixes the case where a postmeta value is an empty string, but the type inside the entity is `?int`. Now denormalizing as null.