### PR TITLE
Query extra EAV properties which are not present in the entity class

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ $products = $manager->getRepository(Product::class)
 
 ### EAV querying
 
+_The term EAV refers to the [entity-attribute-value model](https://en.wikipedia.org/wiki/Entity%E2%80%93attribute%E2%80%93value_model) used by WordPress through the term "meta" as in `wp_postmeta`, `wp_termmeta`, `wp_usermeta` etc. Here we're talking about `wp_postmeta`._
+
 The query system supports directly querying EAV attributes.
-However, it only works with properties that have been declared in the corresponding entity.
 
 In the example below, `sku` and `stock_status` are attributes from `wp_postmeta` table.
 
@@ -142,6 +143,25 @@ $products = $manager->getRepository(Product::class)
 // Fetch all products whose sku match regexp
 $products = $manager->getRepository(Product::class)
     ->findBySku(new Operand('hoodie.*logo|zipper', Operand::OPERATOR_REGEXP));
+
+```
+
+If you query an EAV attribute that doesn't exist in the entity, an `InvalidFieldNameException` exception will be thrown.
+
+To allow extra dynamic properties to be queried, set `allow_extra_properties` option to `true` before the query. Careful though, options are set for the repository and not the query, which means they will apply to all further queries. 
+
+```php
+$page = $manager->getRepository(Page::class)
+    ->setOptions([
+        'allow_extra_properties' => true,
+    ])
+    ->findOneBy([
+        new SelectColumns(['id', select_from_eav('wp_page_template')]),
+        'post_status' => 'publish',
+        'wp_page_template' => 'default',
+    ])
+;
+// $page->wpPageTemplate === 'default'
 ```
 
 ### Nested conditions

--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
 use Doctrine\DBAL\Query\QueryBuilder;
+use JetBrains\PhpStorm\ArrayShape;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -44,6 +45,10 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     protected EntityManagerInterface $entityManager;
     protected SerializerInterface $serializer;
     protected PropertyNormalizer $propertyNormalizer;
+    #[ArrayShape([
+        'allow_extra_properties' => 'bool',
+    ])]
+    protected array $options;
 
     private array $tableAliases = [];
     private array $additionalFieldsToSelect = [];
@@ -52,6 +57,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
         private string $entityClassName,
     ) {
         $this->propertyNormalizer = new PropertyNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
+        $this->setOptions([]);
     }
 
     public function __call(string $name, array $arguments): mixed
@@ -89,6 +95,20 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     public function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
+    }
+
+    public function setOptions(array $options): EntityRepositoryInterface
+    {
+        $resolver = (new OptionsResolver())
+            ->setDefaults([
+                'allow_extra_properties' => false,
+            ])
+            ->setAllowedTypes('allow_extra_properties', 'bool')
+        ;
+
+        $this->options = $resolver->resolve($options);
+
+        return $this;
     }
 
     public function updateSingleField(int $id, string $field, mixed $newValue): bool

--- a/src/Bridge/Repository/EntityPropertiesTrait.php
+++ b/src/Bridge/Repository/EntityPropertiesTrait.php
@@ -71,6 +71,17 @@ trait EntityPropertiesTrait
         return $this->entityExtraFields[$entityClassName];
     }
 
+    protected function addEntityExtraField(string $fieldName, string $entityClassName = null): self
+    {
+        if (!array_key_exists($entityClassName, $this->entityExtraFields)) {
+            $this->getEntityExtraFields($entityClassName);
+        }
+
+        $this->entityExtraFields[$entityClassName][] = $fieldName;
+
+        return $this;
+    }
+
     /**
      * @return string[]
      */

--- a/src/Bridge/Repository/EntityRepositoryInterface.php
+++ b/src/Bridge/Repository/EntityRepositoryInterface.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Query\QueryBuilder;
 
 interface EntityRepositoryInterface extends RepositoryInterface
 {
+    public function setOptions(array $options): self;
+
     public function find(int $id): mixed;
 
     public function findOneBy(array $criteria, array $orderBy = null): mixed;


### PR DESCRIPTION
If you query an EAV attribute that doesn't exist in the entity, an `InvalidFieldNameException` exception will be thrown.

To allow extra dynamic properties to be queried, set `allow_extra_properties` option to `true` before the query. Careful though, options are set for the repository and not the query, which means they will apply to all further queries. 

```php
$page = $manager->getRepository(Page::class)
    ->setOptions([
        'allow_extra_properties' => true,
    ])
    ->findOneBy([
        new SelectColumns(['id', select_from_eav('wp_page_template')]),
        'post_status' => 'publish',
        'wp_page_template' => 'default',
    ])
;
// $page->wpPageTemplate === 'default'
```