### PR TITLE
Query terms from a joint entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,9 @@ jobs:
                 run: composer install
 
             -   name: Install WordPress
-                run: make install
+                run: |
+                    make pause
+                    make install
 
             -   name: Launch test suite
                 run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 CLI=docker compose run --rm wp-cli wp
 
-.PHONY: install reset reset-containers reset-install reset-posts reset-woocommerce
+.PHONY: install pause reset reset-containers reset-install reset-posts reset-woocommerce
 install: reset-install reset-posts reset-woocommerce
 
-reset: reset-containers reset-install reset-posts reset-woocommerce
+pause:
+	@echo "Waiting 20 seconds for environment to be ready..."
+	@sleep 20
+
+reset: reset-containers pause reset-install reset-posts reset-woocommerce
 
 reset-containers:
 	@echo "Preparing containers..."
@@ -11,8 +15,6 @@ reset-containers:
 	@docker compose up -d
 
 reset-install:
-	@echo "Waiting 10 seconds for environment to be ready..."
-	@sleep 10
 	@echo "Installing WordPress..."
 	@$(CLI) core install \
 		--url="http://localhost" \
@@ -52,6 +54,9 @@ reset-woocommerce:
 		--type=simple --regular_price=500 --user=1 --categories='[{"id": 17}]' --sku="super-forces-hoodie" \
 		--attributes='[{"name": "pa_manufacturer", "visible": true, "options": ["MegaBrand"]}]'
 	@$(CLI) post term add 64 pa_manufacturer megabrand
+	@$(CLI) post meta set 22 related_product 18
+	@$(CLI) post meta set 24 related_product 26
+	@$(CLI) post meta set 26 related_product 37
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,38 @@ $products = $manager->getRepository(Product::class)
     ]);
 ```
 
+Additionally, you can query terms from a joint entity, and specify the name of the term table.
+
+In this example, we assume that the products have a `related_product` postmeta.
+```php
+// Fetch a product's category and the category of its related product
+$product = $repository->findOneBy([
+    new SelectColumns([
+        'id',
+        'main.name AS category',
+        'related.name AS related_category',
+        select_from_eav(
+            fieldName: 'related_product',
+            metaKey: 'related_product', // needed as it's not starting with an underscore
+        ),
+    ]),
+    new TermRelationshipCondition(
+        ['taxonomy' => 'product_cat'],
+        termTableAlias: 'main',
+    ),
+    new TermRelationshipCondition(
+        ['taxonomy' => 'product_cat'],
+        joinConditionField: 'related_product',
+        termTableAlias: 'related',
+    ),
+    'id' => 22,
+]);
+// $product->category === 'Hoodies'
+// $product->relatedCategory === 'Accessories'
+```
+
+If not specified, the term table alias defaults to `t_0`, `t_1`, etc.
+
 ### Post relationship conditions
 
 Query terms based on their posts relationships.

--- a/src/Criteria/TermRelationshipCondition.php
+++ b/src/Criteria/TermRelationshipCondition.php
@@ -6,13 +6,27 @@ namespace Williarin\WordpressInterop\Criteria;
 
 final class TermRelationshipCondition
 {
+    public const IDENTIFIER = 'identifier';
+
     public function __construct(
         private array $criteria,
+        private string $joinConditionField = self::IDENTIFIER,
+        private ?string $termTableAlias = null,
     ) {
     }
 
     public function getCriteria(): array
     {
         return $this->criteria;
+    }
+
+    public function getJoinConditionField(): string
+    {
+        return $this->joinConditionField;
+    }
+
+    public function getTermTableAlias(): ?string
+    {
+        return $this->termTableAlias;
     }
 }

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -358,6 +358,32 @@ class ProductRepositoryTest extends TestCase
         self::assertEquals($expected, $product);
     }
 
+    public function testRetrieveCategoryOfRelatedProduct(): void
+    {
+        $products = $this->repository->findBy([
+            new SelectColumns([
+                'id',
+                'post_title',
+                'main.name AS category',
+                'related.name AS related_category',
+                select_from_eav(fieldName: 'related_product', metaKey: 'related_product'),
+            ]),
+            new TermRelationshipCondition(
+                ['taxonomy' => 'product_cat'],
+                termTableAlias: 'main',
+            ),
+            new TermRelationshipCondition(
+                ['taxonomy' => 'product_cat'],
+                joinConditionField: 'related_product',
+                termTableAlias: 'related',
+            ),
+            'id' => new Operand([22, 24, 26], Operand::OPERATOR_IN),
+        ]);
+
+        self::assertEquals(['Hoodies', 'Tshirts', 'Music'], array_column($products, 'category'));
+        self::assertEquals(['Accessories', 'Music', 'Decor'], array_column($products, 'relatedCategory'));
+    }
+
     public function testEmptyStringForIntEAVRetrieval(): void
     {
         $this->manager->getRepository(PostMeta::class)


### PR DESCRIPTION
In this example, we assume that the products have a `related_product` postmeta.
```php
// Fetch a product's category and the category of its related product
$product = $repository->findOneBy([
    new SelectColumns([
        'id',
        'main.name AS category',
        'related.name AS related_category',
        select_from_eav(
            fieldName: 'related_product',
            metaKey: 'related_product', // needed as it's not starting with an underscore
        ),
    ]),
    new TermRelationshipCondition(
        ['taxonomy' => 'product_cat'],
        termTableAlias: 'main',
    ),
    new TermRelationshipCondition(
        ['taxonomy' => 'product_cat'],
        joinConditionField: 'related_product',
        termTableAlias: 'related',
    ),
    'id' => 22,
]);
// $product->category === 'Hoodies'
// $product->relatedCategory === 'Accessories'
```