### PR TITLE
Fix IN operator with associative arrays

### DIFF
--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -371,9 +371,10 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
                     range(0, count($value) - 1),
                 );
                 $parameter = sprintf('(:%s)', implode(', :', $parameters));
+                $listValue = array_values($value);
 
                 foreach ($parameters as $index => $name) {
-                    $queryBuilder->setParameter($name, $value[$index]);
+                    $queryBuilder->setParameter($name, $listValue[$index]);
                 }
             } else {
                 $queryBuilder->setParameter($snakeField, $criteria[$field]->getOperand());

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -246,6 +246,17 @@ class ProductRepositoryTest extends TestCase
         self::assertEquals([17, 27], array_column($products, 'id'));
     }
 
+    public function testOperatorInWithAssociativeArray(): void
+    {
+        $products = $this->repository->findBySku(
+            new Operand([1 => 'woo-tshirt', 'key' => 'woo-single'], Operand::OPERATOR_IN),
+        );
+        self::assertIsArray($products);
+        self::assertCount(2, $products);
+        self::assertContainsOnlyInstancesOf(Product::class, $products);
+        self::assertEquals([17, 27], array_column($products, 'id'));
+    }
+
     public function testTermRelationshipConditionWithTaxonomyOnly(): void
     {
         $products = $this->repository->findBy([


### PR DESCRIPTION
This doesn't fail anymore:

```php
$products = $repository->findBySku(
    new Operand([1 => 'woo-tshirt', 'key' => 'woo-single'], Operand::OPERATOR_IN),
);
```