### PR TITLE
Fix `GenericData` denormalization

### DIFF
--- a/src/Serializer/SerializedArrayDenormalizer.php
+++ b/src/Serializer/SerializedArrayDenormalizer.php
@@ -29,10 +29,10 @@ final class SerializedArrayDenormalizer implements DenormalizerInterface
     ): array|string|int|float|bool|\ArrayObject|AttachmentMetadata|GenericData|null {
         $unserialized = unserialize_if_needed($data);
 
-        if ($data !== $unserialized) {
+        if ($data !== $unserialized || empty($unserialized)) {
             if ($type === GenericData::class) {
                 $unserialized = [
-                    'data' => $unserialized,
+                    'data' => $unserialized ?: [],
                 ];
             }
 

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -7,6 +7,7 @@ namespace Williarin\WordpressInterop\Test\Bridge\Repository;
 use Williarin\WordpressInterop\Bridge\Entity\PostMeta;
 use Williarin\WordpressInterop\Bridge\Entity\Product;
 use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
+use Williarin\WordpressInterop\Bridge\Type\GenericData;
 use Williarin\WordpressInterop\Criteria\NestedCondition;
 use Williarin\WordpressInterop\Criteria\Operand;
 use Williarin\WordpressInterop\Criteria\SelectColumns;
@@ -441,5 +442,18 @@ class ProductRepositoryTest extends TestCase
 
         $product = $this->repository->find(14);
         self::assertNull($product->thumbnailId);
+    }
+
+    public function testWrongTypeForGenericData(): void
+    {
+        $this->manager->getRepository(PostMeta::class)
+            ->update(14, '_default_attributes', null)
+        ;
+
+        $product = $this->repository->find(14);
+        $expected = new GenericData();
+        $expected->data = [];
+
+        self::assertEquals($expected, $product->defaultAttributes);
     }
 }


### PR DESCRIPTION
If a field mapped to `GenericData` property is null, the denormalization doesn't fail anymore.