### PR TITLE
Allow empty array provided to IN, IN ALL or NOT IN operators

### DIFF
--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -377,6 +377,10 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
                     true
                 )
             ) {
+                if (count($value) === 0) {
+                    $value[] = md5((string) time());
+                }
+
                 $parameters = array_map(
                     static fn (int $number) => "{$snakeField}_{$number}",
                     range(0, count($value) - 1),

--- a/test/Test/Bridge/Repository/PostRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostRepositoryTest.php
@@ -189,6 +189,15 @@ class PostRepositoryTest extends TestCase
         self::assertEquals([11], array_column($posts, 'id'));
     }
 
+    public function testOperatorNotInEmptyArray(): void
+    {
+        $posts = $this->repository->findBy(['post_status' => new Operand([], Operand::OPERATOR_NOT_IN)]);
+        self::assertIsArray($posts);
+        self::assertCount(4, $posts);
+        self::assertContainsOnlyInstancesOf(Post::class, $posts);
+        self::assertEquals([12, 11, 1, 10], array_column($posts, 'id'));
+    }
+
     public function testOperatorNotInWithMagicMethod(): void
     {
         $posts = $this->repository->findByPostStatus(new Operand(['draft', 'private'], Operand::OPERATOR_NOT_IN));

--- a/test/Test/Bridge/Repository/ProductRepositoryTest.php
+++ b/test/Test/Bridge/Repository/ProductRepositoryTest.php
@@ -268,6 +268,15 @@ class ProductRepositoryTest extends TestCase
         self::assertEquals([17, 27], array_column($products, 'id'));
     }
 
+    public function testOperatorInWithEmptyArray(): void
+    {
+        $products = $this->repository->findBySku(
+            new Operand([], Operand::OPERATOR_IN),
+        );
+        self::assertIsArray($products);
+        self::assertCount(0, $products);
+    }
+
     public function testTermRelationshipConditionWithTaxonomyOnly(): void
     {
         $products = $this->repository->findBy([
@@ -341,6 +350,17 @@ class ProductRepositoryTest extends TestCase
 
         self::assertCount(2, $products);
         self::assertEquals([20, 21], array_column($products, 'id'));
+    }
+
+    public function testTermRelationshipConditionWithInAllOperatorEmptyArray(): void
+    {
+        $products = $this->repository->findBy([
+            new TermRelationshipCondition([
+                'slug' => new Operand([], Operand::OPERATOR_IN_ALL),
+            ]),
+        ]);
+
+        self::assertCount(0, $products);
     }
 
     public function testTermRelationshipConditionWithInAllOperatorNotReturningResults(): void


### PR DESCRIPTION
This won't throw an exception anymore:

```php
$products = $repository->findBySku(
    new Operand([], Operand::OPERATOR_IN),
);
```

Instead it returns zero result as expected. Same goes for `Operand::OPERATOR_IN`.
In the contrary, `Operand::OPERATOR_NOT_IN` will return all results.