### PR TITLE
Fix add duplicated terms to an entity

### DIFF
--- a/src/Bridge/Repository/TermRepository.php
+++ b/src/Bridge/Repository/TermRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Bridge\Repository;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
 use Williarin\WordpressInterop\Bridge\Entity\Term;
@@ -62,17 +63,20 @@ class TermRepository extends AbstractEntityRepository
                 continue;
             }
 
-            $this->entityManager->getConnection()
-                ->createQueryBuilder()
-                ->insert($this->entityManager->getTablesPrefix() . 'term_relationships')
-                ->values([
-                    'object_id' => '?',
-                    'term_taxonomy_id' => '?',
-                    'term_order' => '0',
-                ])
-                ->setParameters([$entity->id, (int) $term->termTaxonomyId])
-                ->executeStatement()
-            ;
+            try {
+                $this->entityManager->getConnection()
+                    ->createQueryBuilder()
+                    ->insert($this->entityManager->getTablesPrefix() . 'term_relationships')
+                    ->values([
+                        'object_id' => '?',
+                        'term_taxonomy_id' => '?',
+                        'term_order' => '0',
+                    ])
+                    ->setParameters([$entity->id, (int) $term->termTaxonomyId])
+                    ->executeStatement()
+                ;
+            } catch (UniqueConstraintViolationException) {
+            }
         }
 
         $this->recountTerms();

--- a/test/Test/Bridge/Repository/TermRepositoryTest.php
+++ b/test/Test/Bridge/Repository/TermRepositoryTest.php
@@ -231,6 +231,39 @@ class TermRepositoryTest extends TestCase
         self::assertEquals(['simple'], array_column($terms, 'name'));
     }
 
+    public function testRemoveTermsFromEntityWhichDoesNotHaveThemDoesNothing(): void
+    {
+        $product = $this->manager->getRepository(Product::class)
+            ->findOneBySku('super-forces-hoodie')
+        ;
+
+        $terms = $this->repository->findBy([
+            new PostRelationshipCondition(Product::class, [
+                'id' => $product->id,
+            ]),
+        ]);
+
+        self::assertEquals(['simple', 'Hoodies', 'MegaBrand'], array_column($terms, 'name'));
+
+        $unrelatedTerms = $this->repository->findBy([
+            new PostRelationshipCondition(Product::class, [
+                'id' => 37,
+            ]),
+        ]);
+
+        self::assertEquals(['external', 'Decor'], array_column($unrelatedTerms, 'name'));
+
+        $this->repository->removeTermsFromEntity($product, $unrelatedTerms);
+
+        $terms = $this->repository->findBy([
+            new PostRelationshipCondition(Product::class, [
+                'id' => $product->id,
+            ]),
+        ]);
+
+        self::assertEquals(['simple', 'Hoodies', 'MegaBrand'], array_column($terms, 'name'));
+    }
+
     public function testRemoveTermsFromEntityWithoutTermTaxonomyIdAreIgnored(): void
     {
         $product = $this->manager->getRepository(Product::class)


### PR DESCRIPTION
No more `UniqueConstraintViolationException` thrown when adding a term to an entity which already have it.