### PR TITLE
Dedicated service container for manager-related services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
 
         strategy:
             matrix:
-                php: ['8.0', '8.1']
+                php: ['8.0', '8.1', '8.2']
                 experimental: [false]
                 include:
-                    -   php: '8.2'
+                    -   php: '8.3'
                         experimental: true
 
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
         paths-ignore:
             - '**/README.md'
 
+concurrency:
+    group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+    cancel-in-progress: true
+
 jobs:
     test:
         name: Test
@@ -27,7 +31,7 @@ jobs:
                         experimental: true
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
 
             -   name: Spin up Docker containers
                 run: make reset-containers
@@ -45,10 +49,10 @@ jobs:
 
             -   name: Get composer cache directory
                 id: composer-cache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+                run: echo "dir="$(composer config cache-files-dir)"" >> $GITHUB_OUTPUT
 
             -   name: Cache dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $allPosts = $postRepository->findAll();
 ### Basic querying
 
 This works with any entity inherited from `BaseEntity`.
-Built-in entities are `Post`, `Page`, `Attachment` and `Product` but you can [create your own](#create-your-own-repositories).
+Built-in entities are `Post`, `Page`, `Attachment` and `Product` but you can [create your own](#create-your-own-entities-and-repositories).
 
 ```php
 // Fetch a post by ID
@@ -409,7 +409,9 @@ Duplicate an entity with all its EAV attributes and terms with `DuplicationServi
 The resulting entity is already persisted and has a new ID.
 
 ```php
-$duplicationService = $manager->getDuplicationService();
+$duplicationService = $registry->get(DuplicationService::class);
+// or
+$duplicationService = DuplicationService::create($manager);
 
 // Duplicate by ID
 $newProduct =  $duplicationService->duplicate(23, Product::class);

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "require": {
         "php": ">=8.0",
         "doctrine/dbal": "^3.3",
+        "symfony/config": "^6.0",
+        "symfony/dependency-injection": "^6.0",
         "symfony/options-resolver": "^6.0",
         "symfony/property-access": "^6.0",
         "symfony/serializer": "^6.0",
         "symfony/serializer-pack": "^1.1",
-        "symfony/translation-contracts": "^3.0",
-        "symfony/dependency-injection": "^6.0",
-        "symfony/config": "^6.0"
+        "symfony/translation-contracts": "^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.23",
@@ -53,14 +53,14 @@
             "Williarin\\WordpressInterop\\Test\\Fixture\\": "test/Fixture/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
-    },
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "symfony/property-access": "^6.0",
         "symfony/serializer": "^6.0",
         "symfony/serializer-pack": "^1.1",
-        "symfony/translation-contracts": "^3.0"
+        "symfony/translation-contracts": "^3.0",
+        "symfony/dependency-injection": "^6.0",
+        "symfony/config": "^6.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.23",
@@ -34,8 +36,8 @@
         "roave/security-advisories": "dev-latest",
         "symfony/dotenv": "^6.0",
         "symfony/var-dumper": "^6.0",
-        "symplify/coding-standard": "^10.0",
-        "symplify/easy-coding-standard": "^10.0"
+        "symplify/coding-standard": "^11.0",
+        "symplify/easy-coding-standard": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Williarin\WordpressInterop\Persistence\DuplicationService;
+use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
+
+return static function(ContainerConfigurator $containerConfigurator) {
+    $services = $containerConfigurator->services();
+
+    $services->set(DuplicationService::class)
+        ->factory([null, 'create']);
+
+    $services->alias(DuplicationServiceInterface::class, DuplicationService::class)
+        ->public();
+};

--- a/ecs.php
+++ b/ecs.php
@@ -27,7 +27,6 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->sets([
         SetList::SYMPLIFY,
         SetList::PSR_12,
-        SetList::PHP_CS_FIXER,
         SetList::DOCTRINE_ANNOTATIONS,
         SetList::CLEAN_CODE,
     ]);

--- a/src/AbstractEntityManager.php
+++ b/src/AbstractEntityManager.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop;
 
 use Doctrine\DBAL\Connection;
+use JetBrains\PhpStorm\Deprecated;
 use ReflectionClass;
 use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\String\Slugger\AsciiSlugger;
 use Williarin\WordpressInterop\Attributes\RepositoryClass;
 use Williarin\WordpressInterop\Bridge\Entity\BaseEntity;
 use Williarin\WordpressInterop\Bridge\Repository\RepositoryInterface;
@@ -17,15 +17,17 @@ use Williarin\WordpressInterop\Persistence\DuplicationServiceInterface;
 abstract class AbstractEntityManager implements EntityManagerInterface
 {
     private array $repositories = [];
-    private ?DuplicationServiceInterface $duplicationService;
+
+    #[Deprecated]
+    private ?DuplicationServiceInterface $duplicationService = null;
 
     public function __construct(
         private Connection $connection,
         protected SerializerInterface $serializer,
         private string $tablePrefix = 'wp_',
+        #[Deprecated]
         DuplicationServiceInterface $duplicationService = null,
     ) {
-        $this->duplicationService = $duplicationService;
     }
 
     public function addRepository(RepositoryInterface $repository): EntityManagerInterface
@@ -54,13 +56,14 @@ abstract class AbstractEntityManager implements EntityManagerInterface
         return $this->repositories[$entityClassName];
     }
 
+    /**
+     * @deprecated Since 1.12.0, use DuplicationService::create($this) instead. Will be removed in 2.0
+     */
     public function getDuplicationService(): DuplicationServiceInterface
     {
         if (!$this->duplicationService) {
-            $this->duplicationService = new DuplicationService(new AsciiSlugger());
+            $this->duplicationService = DuplicationService::create($this);
         }
-
-        $this->duplicationService->setEntityManager($this);
 
         return $this->duplicationService;
     }

--- a/src/Bridge/Entity/PostMeta.php
+++ b/src/Bridge/Entity/PostMeta.php
@@ -10,8 +10,8 @@ use Williarin\WordpressInterop\Bridge\Repository\PostMetaRepository;
 #[RepositoryClass(PostMetaRepository::class)]
 class PostMeta
 {
-//    public ?int $metaId = null;
-//    public ?int $postId = null;
-//    public ?string $metaKey = null;
-//    public string|array|int|float|bool|null $metaValue = null;
+    //    public ?int $metaId = null;
+    //    public ?int $postId = null;
+    //    public ?string $metaKey = null;
+    //    public string|array|int|float|bool|null $metaValue = null;
 }

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -21,6 +21,9 @@ interface EntityManagerInterface
 
     public function getTablesPrefix(): string;
 
+    /**
+     * @deprecated Since 1.12.0, use DuplicationService::create($this) instead. Will be removed in 2.0
+     */
     public function getDuplicationService(): DuplicationServiceInterface;
 
     public function persist(BaseEntity $entity): void;

--- a/src/ManagerRegistryInterface.php
+++ b/src/ManagerRegistryInterface.php
@@ -25,5 +25,13 @@ interface ManagerRegistryInterface
 
     public function getRepository(string $entityClassName, ?string $managerName = null): RepositoryInterface;
 
+    /**
+     * @deprecated Since 1.12.0, use get(DuplicationServiceInterface::class) instead. Will be removed in 2.0
+     */
     public function getDuplicationService(?string $managerName = null): DuplicationServiceInterface;
+
+    /**
+     * Get a service from the dedicated service container
+     */
+    public function get(string $serviceId, ?string $managerName = null): ?object;
 }

--- a/src/Persistence/DuplicationService.php
+++ b/src/Persistence/DuplicationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Williarin\WordpressInterop\Persistence;
 
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Williarin\WordpressInterop\Attributes\Slug;
 use Williarin\WordpressInterop\Attributes\Unique;
@@ -21,8 +22,20 @@ final class DuplicationService implements DuplicationServiceInterface, EntityMan
 {
     private ?EntityManagerInterface $entityManager = null;
 
-    public function __construct(private SluggerInterface $slugger)
+    public function __construct(
+        private SluggerInterface $slugger
+    ) {
+    }
+
+    public static function create(EntityManagerInterface $entityManager = null): self
     {
+        $duplicationService = new self(new AsciiSlugger());
+
+        if ($entityManager) {
+            $duplicationService->setEntityManager($entityManager);
+        }
+
+        return $duplicationService;
     }
 
     public function setEntityManager(EntityManagerInterface $entityManager): void

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+final class ServiceContainer
+{
+    private ContainerBuilder $container;
+
+    public function __construct()
+    {
+        $this->initContainer();
+    }
+
+    public function get(string $id): ?object
+    {
+        return $this->container->get($id);
+    }
+
+    private function initContainer(): void
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../config'));
+        $loader->load('services.php');
+
+        $container->compile();
+
+        $this->container = $container;
+    }
+}

--- a/test/Test/ManagerRegistryTest.php
+++ b/test/Test/ManagerRegistryTest.php
@@ -77,6 +77,28 @@ class ManagerRegistryTest extends TestCase
         $this->managerRegistry->getDuplicationService('fr');
     }
 
+    public function testGetDefaultDuplicationServiceFromServiceContainer(): void
+    {
+        self::assertInstanceOf(
+            DuplicationServiceInterface::class,
+            $this->managerRegistry->get(DuplicationServiceInterface::class),
+        );
+    }
+
+    public function testGetNonExistentDuplicationServiceFromServiceContainer(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->managerRegistry->get(DuplicationServiceInterface::class, 'fr');
+    }
+
+    public function testGetNamedDuplicationServiceFromServiceContainer(): void
+    {
+        self::assertInstanceOf(
+            DuplicationServiceInterface::class,
+            $this->managerRegistry->get(DuplicationServiceInterface::class, 'other'),
+        );
+    }
+
     private function getManagerFactory(): Closure
     {
         return function () {

--- a/test/Test/Persistence/DuplicationServiceTest.php
+++ b/test/Test/Persistence/DuplicationServiceTest.php
@@ -21,7 +21,15 @@ class DuplicationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->duplicationService = $this->manager->getDuplicationService();
+        $this->duplicationService = DuplicationService::create($this->manager);
+    }
+
+    /**
+     * @deprecated Will be removed in 2.0
+     */
+    public function testLegacyGetDuplicationService(): void
+    {
+        self::assertInstanceOf(DuplicationServiceInterface::class, $this->manager->getDuplicationService());
     }
 
     public function testDuplicateByIdWithoutEntityClassNameThrowsException(): void


### PR DESCRIPTION
This change deprecates all `getDuplicationService()` methods found in `ManagerRegistryInterface` or `EntityManagerInterface`. These methods will be removed in 2.0 release.

Instead, there are several new ways to retrieve the `DuplicationService` linked to the entity manager we need:
```php
// Using default entity manager
$duplicationService = $registry->get(DuplicationService::class);
// Using custom entity manager
$duplicationService = $registry->get(DuplicationService::class, 'custom');
// Using $entityManager
$duplicationService = DuplicationService::create($entityManager);
```

This change will allow to retrieve more services without modifying the interfaces.