### PR TITLE
Create a new term

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,16 @@ $result = $repository->createFindByQueryBuilder([], ['sku' => 'ASC'])
 $products = $repository->denormalize($result, Product::class . '[]');
 ```
 
+### Create a new term
+
+Terms are not duplicated if already existing.
+
+```php
+// Create a new product category
+$repository = $manager->getRepository(Term::class);
+$term = $repository->createTermForTaxonomy('Jewelry', 'product_cat');
+```
+
 ### Add terms to an entity
 
 ```php
@@ -429,6 +439,7 @@ $newProduct =  $duplicationService->duplicate($product);
 * `Option` and `OptionRepository`
 * `PostMeta` and `PostMetaRepository`
 * `Term` and `TermRepository`
+* `TermTaxonomy` and `TermTaxonomyRepository`
 * `User` and `UserRepository`
 * `Product` and `ProductRepository` (WooCommerce)
 * `ShopOrder` and `ShopOrderRepository` (WooCommerce)

--- a/src/Bridge/Entity/DynamicPropertiesTrait.php
+++ b/src/Bridge/Entity/DynamicPropertiesTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Williarin\WordpressInterop\Bridge\Entity;
 
 use ReflectionNamedType;
+use Williarin\WordpressInterop\Exception\InvalidArgumentException;
+use Williarin\WordpressInterop\Exception\MethodNotFoundException;
 
 trait DynamicPropertiesTrait
 {
@@ -18,7 +20,7 @@ trait DynamicPropertiesTrait
             $reflectionType = (new \ReflectionProperty(static::class, $property))->getType();
 
             $expectedType = $reflectionType instanceof ReflectionNamedType
-                ? $reflectionType?->getName()
+                ? $reflectionType->getName()
                 : (string) $reflectionType;
 
             settype($value, $expectedType);
@@ -31,5 +33,31 @@ trait DynamicPropertiesTrait
     public function __get(string $property): mixed
     {
         return $this->{$property};
+    }
+
+    public function __isset($name): bool
+    {
+        return property_exists($this, $name);
+    }
+
+    public function __call(string $name, array $arguments): mixed
+    {
+        $propertyName = lcfirst(substr($name, 3));
+
+        if (preg_match('/^get[A-Z]/', $name)) {
+            return $this->__get($propertyName);
+        }
+
+        if (preg_match('/^set[A-Z]/', $name)) {
+            if (count($arguments) !== 1) {
+                throw new InvalidArgumentException('Setter needs a value as argument.');
+            }
+
+            $this->__set($propertyName, $arguments[0]);
+
+            return $this;
+        }
+
+        throw new MethodNotFoundException(static::class, $name);
     }
 }

--- a/src/Bridge/Entity/Term.php
+++ b/src/Bridge/Entity/Term.php
@@ -35,4 +35,16 @@ class Term
 
     #[External]
     public ?int $count = null;
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function setSlug(?string $slug): self
+    {
+        $this->slug = $slug;
+        return $this;
+    }
 }

--- a/src/Bridge/Entity/TermTaxonomy.php
+++ b/src/Bridge/Entity/TermTaxonomy.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Bridge\Entity;
+
+use AllowDynamicProperties;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Williarin\WordpressInterop\Attributes\Id;
+use Williarin\WordpressInterop\Attributes\RepositoryClass;
+use Williarin\WordpressInterop\Bridge\Repository\TermTaxonomyRepository;
+
+#[AllowDynamicProperties]
+#[RepositoryClass(TermTaxonomyRepository::class)]
+class TermTaxonomy
+{
+    #[Id]
+    #[Groups('base')]
+    public ?int $termTaxonomyId = null;
+
+    #[Groups('base')]
+    public ?int $termId = null;
+
+    #[Groups('base')]
+    public ?string $taxonomy = null;
+
+    #[Groups('base')]
+    public ?string $description = null;
+
+    #[Groups('base')]
+    public int $parent = 0;
+
+    #[Groups('base')]
+    public int $count = 0;
+
+    public function setTermId(?int $termId): self
+    {
+        $this->termId = $termId;
+        return $this;
+    }
+
+    public function setTaxonomy(?string $taxonomy): self
+    {
+        $this->taxonomy = $taxonomy;
+        return $this;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function setParent(int $parent): self
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    public function setCount(int $count): self
+    {
+        $this->count = $count;
+        return $this;
+    }
+}

--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -189,7 +189,9 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
 
         unset($baseFields[static::TABLE_IDENTIFIER]);
 
-        if ($entity->{static::TABLE_IDENTIFIER} === null) {
+        $identifierProperty = field_to_property(static::TABLE_IDENTIFIER);
+
+        if ($entity->{$identifierProperty} === null) {
             $this->entityManager->getConnection()
                 ->createQueryBuilder()
                 ->insert($this->entityManager->getTablesPrefix() . static::TABLE_NAME)
@@ -198,7 +200,8 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
                 ->executeStatement()
             ;
 
-            $entity->{static::TABLE_IDENTIFIER} = (int) $this->entityManager->getConnection()->lastInsertId();
+            $entity->{$identifierProperty} = (int) $this->entityManager->getConnection()
+                ->lastInsertId();
         } else {
             $queryBuilder = $this->entityManager->getConnection()
                 ->createQueryBuilder()

--- a/src/Bridge/Repository/TermTaxonomyRepository.php
+++ b/src/Bridge/Repository/TermTaxonomyRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Williarin\WordpressInterop\Bridge\Repository;
+
+use Williarin\WordpressInterop\Bridge\Entity\TermTaxonomy;
+
+class TermTaxonomyRepository extends AbstractEntityRepository
+{
+    protected const TABLE_NAME = 'term_taxonomy';
+    protected const TABLE_IDENTIFIER = 'term_taxonomy_id';
+    protected const FALLBACK_ENTITY = TermTaxonomy::class;
+
+    public function __construct()
+    {
+        parent::__construct(TermTaxonomy::class);
+    }
+}

--- a/test/Test/Bridge/Repository/PostRepositoryTest.php
+++ b/test/Test/Bridge/Repository/PostRepositoryTest.php
@@ -9,6 +9,7 @@ use Williarin\WordpressInterop\Bridge\Entity\Post;
 use Williarin\WordpressInterop\Bridge\Repository\EntityRepositoryInterface;
 use Williarin\WordpressInterop\Criteria\Operand;
 use Williarin\WordpressInterop\Exception\EntityNotFoundException;
+use Williarin\WordpressInterop\Exception\InvalidArgumentException;
 use Williarin\WordpressInterop\Exception\InvalidEntityException;
 use Williarin\WordpressInterop\Exception\InvalidFieldNameException;
 use Williarin\WordpressInterop\Exception\InvalidOrderByOrientationException;
@@ -266,5 +267,37 @@ class PostRepositoryTest extends TestCase
 
         self::assertSame('Another post with a new title', $post->postTitle);
         self::assertSame('publish', $post->postStatus);
+    }
+
+    public function testDynamicSetter(): void
+    {
+        $post = new Post();
+
+        $post = $post->setDynamicProperty('Hello');
+        self::assertSame('Hello', $post->dynamicProperty);
+    }
+
+    public function testDynamicSetterNoArgument(): void
+    {
+        $post = new Post();
+
+        $this->expectException(InvalidArgumentException::class);
+        $post->setDynamicProperty();
+    }
+
+    public function testWrongMethodCall(): void
+    {
+        $post = new Post();
+
+        $this->expectException(MethodNotFoundException::class);
+        $post->nonExistentMethod();
+    }
+
+    public function testDynamicGetter(): void
+    {
+        $post = new Post();
+        $post->postContent = 'Hello';
+
+        self::assertSame('Hello', $post->getPostContent());
     }
 }


### PR DESCRIPTION
Terms are not duplicated if already existing.

```php
// Create a new product category
$repository = $manager->getRepository(Term::class);
$term = $repository->createTermForTaxonomy('Jewelry', 'product_cat');
```