### PR TITLE
Fix Symfony 6.3 deprecation warning

### DIFF
--- a/src/Serializer/SerializedArrayDenormalizer.php
+++ b/src/Serializer/SerializedArrayDenormalizer.php
@@ -41,4 +41,12 @@ final class SerializedArrayDenormalizer implements DenormalizerInterface
 
         return $data;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AttachmentMetadata::class => true,
+            GenericData::class => true,
+        ];
+    }
 }


### PR DESCRIPTION
Fix this deprecation:

`User Deprecated: Since symfony/serializer 6.3: Not implementing the "NormalizerInterface::getSupportedTypes()" in "Williarin\WordpressInterop\Serializer\SerializedArrayDenormalizer" is deprecated.`