### PR TITLE
Fix array to string conversion when normalizing criteria

### DIFF
--- a/src/Bridge/Repository/AbstractEntityRepository.php
+++ b/src/Bridge/Repository/AbstractEntityRepository.php
@@ -229,7 +229,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
             $mappedFields = $targetClass->getMappedFields();
         } else {
             // BC layer, to be removed when MAPPED_FIELDS constant is removed
-            $mappedFields = (new \ReflectionClassConstant($targetClass, 'MAPPED_FIELDS',))->getValue();
+            $mappedFields = (new \ReflectionClassConstant($targetClass, 'MAPPED_FIELDS'))->getValue();
         }
 
         if (
@@ -257,7 +257,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
             $mappedFields = $targetClass->getMappedFields();
         } else {
             // BC layer, to be removed when MAPPED_FIELDS constant is removed
-            $mappedFields = (new \ReflectionClassConstant($targetClass, 'MAPPED_FIELDS',))->getValue();
+            $mappedFields = (new \ReflectionClassConstant($targetClass, 'MAPPED_FIELDS'))->getValue();
         }
 
         if (
@@ -408,10 +408,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
         string $entityClassName = null,
         int $aliasNumber = null,
     ): CompositeExpression {
-        $snakeField = u($field)
-            ->snake()
-            ->toString()
-        ;
+        $snakeField = str_replace('.', '_', u($field) ->snake() ->toString());
         $parameter = ":{$snakeField}";
         $operator = '=';
         $prefixedField = $field;
@@ -476,10 +473,7 @@ abstract class AbstractEntityRepository implements EntityRepositoryInterface
     ])]
     private function flattenOperand(QueryBuilder $queryBuilder, Operand $operand, string $field, mixed $value): array
     {
-        $snakeField = u($field)
-            ->snake()
-            ->toString()
-        ;
+        $snakeField = str_replace('.', '_', u($field) ->snake() ->toString());
         $parameter = ":{$snakeField}";
         $operator = $operand->getOperator();
 

--- a/src/Bridge/Repository/NormalizerTrait.php
+++ b/src/Bridge/Repository/NormalizerTrait.php
@@ -53,7 +53,7 @@ trait NormalizerTrait
                 $resolvedValue = $ignoreValidation
                     ? $value
                     : $this->validateFieldValue($field, $value, $entityClassName);
-                $output[$field] = (string) $this->serializer->normalize($resolvedValue);
+                $output[$field] = $this->serializer->normalize($resolvedValue);
             }
         }
 


### PR DESCRIPTION
In some cases the criteria field is an Operand object so it's normalized as an array and not a string.